### PR TITLE
Debug mask import and variable consisency

### DIFF
--- a/client/apps/apps.go
+++ b/client/apps/apps.go
@@ -436,7 +436,7 @@ func createAsyncApp(app application, developerEntities developers.Appdevelopers,
 	temporaryCredential := newAppCredentials[0].(map[string]interface{})
 	printSetting := apiclient.GetPrintOutput()
 	apiclient.SetPrintOutput(false)
-	_, err = DeleteKey(developerEmail, newDeveloperApp["name"].(string), temporaryCredential["consumerKey"].(string))
+	_, err = DeleteKey(url.QueryEscape(developerEmail), newDeveloperApp["name"].(string), temporaryCredential["consumerKey"].(string)) //since developer emails can have +
 	apiclient.SetPrintOutput(printSetting)
 	if err != nil {
 		clilog.Error.Println(err)

--- a/client/env/debugmask.go
+++ b/client/env/debugmask.go
@@ -33,13 +33,17 @@ func GetDebug() (respBody []byte, err error) {
 //SetDebug
 func SetDebug(maskConfig string) (respBody []byte, err error) {
 	//the following steps will validate json
-	m := map[string]string{}
+	var m map[string]interface{}
 	err = json.Unmarshal([]byte(maskConfig), &m)
 	if err != nil {
 		return respBody, err
 	}
+
 	u, _ := url.Parse(apiclient.BaseURL)
 	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "environments", apiclient.GetApigeeEnv(), "debugmask")
-	respBody, err = apiclient.HttpClient(apiclient.GetPrintOutput(), u.String(), maskConfig)
+	q := u.Query()
+	q.Add("replaceRepeatedFields","true")
+	u.RawQuery = q.Encode()
+	respBody, err = apiclient.HttpClient(apiclient.GetPrintOutput(), u.String(), maskConfig, "PATCH")
 	return respBody, err
 }

--- a/cmd/org/export.go
+++ b/cmd/org/export.go
@@ -170,7 +170,7 @@ var ExportCmd = &cobra.Command{
 			if respBody, err = env.GetDebug(); err != nil {
 				return err
 			}
-			if err = apiclient.WriteByteArrayToFile(environment+"_"+debugmaskFileName, false, respBody); err != nil {
+			if err = apiclient.WriteByteArrayToFile(environment+debugmaskFileName, false, respBody); err != nil {
 				return err
 			}
 
@@ -178,7 +178,7 @@ var ExportCmd = &cobra.Command{
 			if respBody, err = env.GetTraceConfig(); err != nil {
 				return err
 			}
-			if err = apiclient.WriteByteArrayToFile(environment+"_"+tracecfgFileName, false, respBody); err != nil {
+			if err = apiclient.WriteByteArrayToFile(environment+tracecfgFileName, false, respBody); err != nil {
 				return err
 			}
 

--- a/cmd/org/export.go
+++ b/cmd/org/export.go
@@ -180,7 +180,7 @@ var ExportCmd = &cobra.Command{
 			if respBody, err = env.GetDebug(); err != nil {
 				return err
 			}
-			if err = apiclient.WriteByteArrayToFile(environment+debugmaskFileName, false, respBody); proceedOnError(err) != nil {
+			if err = apiclient.WriteByteArrayToFile(environment+"_"+debugmaskFileName, false, respBody); proceedOnError(err) != nil {
 				return err
 			}
 
@@ -188,7 +188,7 @@ var ExportCmd = &cobra.Command{
 			if respBody, err = env.GetTraceConfig(); err != nil {
 				return err
 			}
-			if err = apiclient.WriteByteArrayToFile(environment+tracecfgFileName, false, respBody); proceedOnError(err) != nil {
+			if err = apiclient.WriteByteArrayToFile(environment+"_"+tracecfgFileName, false, respBody); proceedOnError(err) != nil {
 				return err
 			}
 

--- a/cmd/org/export.go
+++ b/cmd/org/export.go
@@ -170,7 +170,7 @@ var ExportCmd = &cobra.Command{
 			if respBody, err = env.GetDebug(); err != nil {
 				return err
 			}
-			if err = apiclient.WriteByteArrayToFile(environment+debugmaskFileName, false, respBody); err != nil {
+			if err = apiclient.WriteByteArrayToFile(environment+"_"+debugmaskFileName, false, respBody); err != nil {
 				return err
 			}
 
@@ -178,7 +178,7 @@ var ExportCmd = &cobra.Command{
 			if respBody, err = env.GetTraceConfig(); err != nil {
 				return err
 			}
-			if err = apiclient.WriteByteArrayToFile(environment+tracecfgFileName, false, respBody); err != nil {
+			if err = apiclient.WriteByteArrayToFile(environment+"_"+tracecfgFileName, false, respBody); err != nil {
 				return err
 			}
 

--- a/cmd/org/import.go
+++ b/cmd/org/import.go
@@ -178,9 +178,9 @@ var ImportCmd = &cobra.Command{
 			}
 
 			if importDebugmask {
-				if isFileExists(path.Join(folder, environment+debugmaskFileName)) {
+				if isFileExists(path.Join(folder, environment+"_"+debugmaskFileName)) {
 					fmt.Println("\tImporting Debug Mask configuration...")
-					debugMask, _ := readEntityFileAsString(path.Join(folder, environment+debugmaskFileName))
+					debugMask, _ := readEntityFileAsString(path.Join(folder, environment+"_"+debugmaskFileName))
 					if _, err = env.SetDebug(debugMask); err != nil {
 						return err
 					}
@@ -188,9 +188,9 @@ var ImportCmd = &cobra.Command{
 			}
 
 			if importTrace {
-				if isFileExists(path.Join(folder, environment+tracecfgFileName)) {
+				if isFileExists(path.Join(folder, environment+"_"+tracecfgFileName)) {
 					fmt.Println("\tImporting Trace configuration...")
-					traceCfg, _ := readEntityFileAsString(path.Join(folder, environment+tracecfgFileName))
+					traceCfg, _ := readEntityFileAsString(path.Join(folder, environment+"_"+tracecfgFileName))
 					if _, err = env.ImportTraceConfig(traceCfg); err != nil {
 						return err
 					}

--- a/cmd/org/variables.go
+++ b/cmd/org/variables.go
@@ -24,8 +24,8 @@ const (
 	kVMFileName          = "kvms.json"
 	keyStoresFileName    = "keystores.json"
 	syncAuthFileName     = "syncauth.json"
-	debugmaskFileName    = "_debugmask.json"
-	tracecfgFileName     = "_tracecfg.json"
+	debugmaskFileName    = "debugmask.json"
+	tracecfgFileName     = "tracecfg.json"
 	referencesFileName   = "references.json"
 
 	proxiesFolderName     = "proxies"


### PR DESCRIPTION
Fix for debug mask import and minor changes to variable names for consistency.

I added "replaceRepeatedFields" query param so insure an existing debug mask gets fully replaced when, for example, a single value is removed from and existing mask.

Thanks for fixing the other stuff with Issue #55.