### PR TITLE
Fix unreported import/export errors

### DIFF
--- a/apiclient/httpclient.go
+++ b/apiclient/httpclient.go
@@ -32,7 +32,6 @@ import (
 
 // PostHttpZip method is used to send resources, proxy bundles, shared flows etc.
 func PostHttpZip(print bool, auth bool, method string, url string, headers map[string]string, zipfile string) (err error) {
-
 	var req *http.Request
 
 	payload, err := os.ReadFile(zipfile)
@@ -40,7 +39,7 @@ func PostHttpZip(print bool, auth bool, method string, url string, headers map[s
 		return err
 	}
 
-	client, err := getHttpClient()
+	client, err := GetHttpClient()
 	if err != nil {
 		return err
 	}
@@ -61,8 +60,8 @@ func PostHttpZip(print bool, auth bool, method string, url string, headers map[s
 		req.Header.Set(headerName, headerValue)
 	}
 
-	if auth { //do not pass auth header when using with archives
-		req, err = setAuthHeader(req)
+	if auth { // do not pass auth header when using with archives
+		req, err = SetAuthHeader(req)
 		if err != nil {
 			return err
 		}
@@ -83,7 +82,6 @@ func PostHttpZip(print bool, auth bool, method string, url string, headers map[s
 
 // PostHttpOctet method is used to send resources, proxy bundles, shared flows etc.
 func PostHttpOctet(print bool, update bool, url string, formParams map[string]string) (respBody []byte, err error) {
-
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
@@ -93,7 +91,7 @@ func PostHttpOctet(print bool, update bool, url string, formParams map[string]st
 			clilog.Error.Printf("failed to open the file %s with error: %v", formParam, err)
 			return nil, err
 		}
-		//get filenanme without extension
+		// get filenanme without extension
 		fileNameWithExt, _ := filepath.Abs(formParam)
 		formValue := strings.TrimSuffix(fileNameWithExt, filepath.Ext(formParam))
 		part, err := writer.CreateFormFile(formName, formValue)
@@ -123,7 +121,7 @@ func PostHttpOctet(print bool, update bool, url string, formParams map[string]st
 
 	var req *http.Request
 
-	client, err := getHttpClient()
+	client, err := GetHttpClient()
 	if err != nil {
 		return nil, err
 	}
@@ -140,14 +138,13 @@ func PostHttpOctet(print bool, update bool, url string, formParams map[string]st
 		return nil, err
 	}
 
-	req, err = setAuthHeader(req)
+	req, err = SetAuthHeader(req)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	resp, err := client.Do(req)
-
 	if err != nil {
 		clilog.Error.Println("error connecting: ", err)
 		return nil, err
@@ -157,7 +154,7 @@ func PostHttpOctet(print bool, update bool, url string, formParams map[string]st
 }
 
 func DownloadFile(url string, auth bool) (resp *http.Response, err error) {
-	client, err := getHttpClient()
+	client, err := GetHttpClient()
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +171,7 @@ func DownloadFile(url string, auth bool) (resp *http.Response, err error) {
 	}
 
 	if auth {
-		req, err = setAuthHeader(req)
+		req, err = SetAuthHeader(req)
 		if err != nil {
 			return nil, err
 		}
@@ -243,11 +240,11 @@ func HttpClient(print bool, params ...string) (respBody []byte, err error) {
 	// The second parameter is url. If only one parameter is sent, assume GET
 	// The third parameter is the payload. The two parameters are sent, assume POST
 	// THe fourth parameter is the method. If three parameters are sent, assume method in param
-	//The fifth parameter is content type
+	// The fifth parameter is content type
 	var req *http.Request
 	contentType := "application/json"
 
-	client, err := getHttpClient()
+	client, err := GetHttpClient()
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +279,7 @@ func HttpClient(print bool, params ...string) (respBody []byte, err error) {
 		return nil, err
 	}
 
-	req, err = setAuthHeader(req)
+	req, err = SetAuthHeader(req)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +288,6 @@ func HttpClient(print bool, params ...string) (respBody []byte, err error) {
 	req.Header.Set("Content-Type", contentType)
 
 	resp, err := client.Do(req)
-
 	if err != nil {
 		clilog.Error.Println("error connecting: ", err)
 		return nil, err
@@ -333,7 +329,7 @@ func getRequest(params []string) (req *http.Request, err error) {
 	return req, err
 }
 
-func setAuthHeader(req *http.Request) (*http.Request, error) {
+func SetAuthHeader(req *http.Request) (*http.Request, error) {
 	if GetApigeeToken() == "" {
 		if err := SetAccessToken(); err != nil {
 			return nil, err
@@ -344,8 +340,7 @@ func setAuthHeader(req *http.Request) (*http.Request, error) {
 	return req, nil
 }
 
-func getHttpClient() (client *http.Client, err error) {
-
+func GetHttpClient() (client *http.Client, err error) {
 	if GetProxyURL() != "" {
 		if pUrl, err := url.Parse(GetProxyURL()); err != nil {
 			client = &http.Client{
@@ -363,7 +358,6 @@ func getHttpClient() (client *http.Client, err error) {
 }
 
 func handleResponse(print bool, resp *http.Response) (respBody []byte, err error) {
-
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/client/targetservers/targetservers.go
+++ b/client/targetservers/targetservers.go
@@ -16,11 +16,12 @@ package targetservers
 
 import (
 	"encoding/json"
-	"io"
+	"errors"
 	"net/url"
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/apigee/apigeecli/apiclient"
@@ -32,21 +33,21 @@ type targetserver struct {
 	Description string   `json:"description,omitempty"`
 	Host        string   `json:"host,omitempty"`
 	Port        int      `json:"port,omitempty"`
-	IsEnabled   *bool    `json:"isEnabled,omitempty"`
+	IsEnabled   bool     `json:"isEnabled,omitempty"`
 	Protocol    string   `json:"protocol,omitempty"`
 	SslInfo     *sslInfo `json:"sSLInfo,omitempty"`
 }
 
 type sslInfo struct {
-	Enabled                *bool       `json:"enabled,omitempty"`
-	ClientAuthEnabled      *bool       `json:"clientAuthEnabled,omitempty"`
-	Keystore               string      `json:"keyStore,omitempty"`
-	Keyalias               string      `json:"keyAlias,omitempty"`
-	Truststore             string      `json:"trustStore,omitempty"`
-	IgnoreValidationErrors *bool       `json:"ignoreValidationErrors,omitempty"`
-	Protocols              []string    `json:"protocols,omitempty"`
-	Ciphers                []string    `json:"ciphers,omitempty"`
-	CommonName             *commonName `json:"commonName,omitempty"`
+	Enabled                bool       `json:"enabled,omitempty"`
+	ClientAuthEnabled      bool       `json:"clientAuthEnabled,omitempty"`
+	Keystore               string     `json:"keyStore,omitempty"`
+	Keyalias               string     `json:"keyAlias,omitempty"`
+	Truststore             string     `json:"trustStore,omitempty"`
+	IgnoreValidationErrors bool       `json:"ignoreValidationErrors,omitempty"`
+	Protocols              []string   `json:"protocols,omitempty"`
+	Ciphers                []string   `json:"ciphers,omitempty"`
+	CommonName             commonName `json:"commonName,omitempty"`
 }
 
 type commonName struct {
@@ -56,83 +57,56 @@ type commonName struct {
 
 // Create
 func Create(name string, description string, host string, port int, enable string, grpc bool, keyStore string, keyAlias string, sslinfo string, tlsenabled bool, clientAuthEnabled bool, ignoreValidationErrors bool) (respBody []byte, err error) {
-	targetsvr := targetserver{}
-	targetsvr.Name = name
+	targetsvr := targetserver{
+		Name: name,
+	}
 
 	return createOrUpdate("create", targetsvr, name, description, host, port, enable, grpc, keyStore, keyAlias, sslinfo, tlsenabled, clientAuthEnabled, ignoreValidationErrors)
 }
 
 // Update
 func Update(name string, description string, host string, port int, enable string, grpc bool, keyStore string, keyAlias string, sslinfo string, tlsenabled bool, clientAuthEnabled bool, ignoreValidationErrors bool) (respBody []byte, err error) {
-
-	var targetRespBody []byte
-	var targetsvr = targetserver{}
-
 	apiclient.SetPrintOutput(false)
-	if targetRespBody, err = Get(name); err != nil {
+	targetRespBody, err := Get(name)
+	if err != nil {
 		return nil, err
 	}
 	apiclient.SetPrintOutput(true)
 
+	targetsvr := targetserver{}
 	if err = json.Unmarshal(targetRespBody, &targetsvr); err != nil {
 		return nil, err
 	}
-
 	return createOrUpdate("update", targetsvr, name, description, host, port, enable, grpc, keyStore, keyAlias, sslinfo, tlsenabled, clientAuthEnabled, ignoreValidationErrors)
 }
 
 func createOrUpdate(action string, targetsvr targetserver, name string, description string, host string, port int, enable string, grpc bool, keyStore string, keyAlias string, sslinfo string, tlsenabled bool, clientAuthEnabled bool, ignoreValidationErrors bool) (respBody []byte, err error) {
-
-	var reqBody []byte
-	sslInfoObj := new(sslInfo)
-
-	if description != "" {
-		targetsvr.Description = description
-	}
-
-	if host != "" {
-		targetsvr.Host = host
-	}
+	targetsvr.Description = description
+	targetsvr.Host = host
+	targetsvr.IsEnabled, _ = strconv.ParseBool(enable)
 
 	if port != -1 {
 		targetsvr.Port = port
 	}
-
 	if grpc {
 		targetsvr.Protocol = "GRPC"
 	}
-
-	if enable != "" {
-		targetsvr.IsEnabled = new(bool)
-		*targetsvr.IsEnabled, _ = strconv.ParseBool(enable)
+	if strings.ToLower(sslinfo) == "true" {
+		targetsvr.SslInfo = &sslInfo{
+			Enabled:                tlsenabled,
+			ClientAuthEnabled:      clientAuthEnabled,
+			IgnoreValidationErrors: ignoreValidationErrors,
+			Keyalias:               keyAlias,
+			Keystore:               keyStore,
+		}
 	}
 
-	if sslinfo != "" {
-		sslInfoObj.Enabled = new(bool)
-		sslInfoObj.ClientAuthEnabled = new(bool)
-		sslInfoObj.IgnoreValidationErrors = new(bool)
-
-		*sslInfoObj.Enabled = tlsenabled
-		*sslInfoObj.ClientAuthEnabled = clientAuthEnabled
-		*sslInfoObj.IgnoreValidationErrors = ignoreValidationErrors
-
-		if keyAlias != "" {
-			sslInfoObj.Keyalias = keyAlias
-		}
-
-		if keyStore != "" {
-			sslInfoObj.Keystore = keyStore
-		}
-
-		targetsvr.SslInfo = sslInfoObj
-	}
-
-	if reqBody, err = json.Marshal(targetsvr); err != nil {
+	reqBody, err := json.Marshal(targetsvr)
+	if err != nil {
 		return nil, err
 	}
 
 	u, _ := url.Parse(apiclient.BaseURL)
-
 	if action == "create" {
 		u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "environments", apiclient.GetApigeeEnv(), "targetservers")
 		respBody, err = apiclient.HttpClient(apiclient.GetPrintOutput(), u.String(), string(reqBody))
@@ -170,177 +144,177 @@ func List() (respBody []byte, err error) {
 
 // Export
 func Export(conn int) (payload [][]byte, err error) {
-
-	//parent workgroup
-	var pwg sync.WaitGroup
-	var mu sync.Mutex
-	const entityType = "targetservers"
-
 	u, _ := url.Parse(apiclient.BaseURL)
-	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "environments", apiclient.GetApigeeEnv(), entityType)
-	//don't print to sysout
+	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "environments", apiclient.GetApigeeEnv(), "targetservers")
+	// don't print to sysout
 	respBody, err := apiclient.HttpClient(false, u.String())
 	if err != nil {
-		return apiclient.GetEntityPayloadList(), err
+		return nil, err
 	}
 
 	var targetservers []string
 	err = json.Unmarshal(respBody, &targetservers)
 	if err != nil {
-		return apiclient.GetEntityPayloadList(), err
+		return nil, err
 	}
 
-	numEntities := len(targetservers)
-	clilog.Info.Printf("Found %d targetservers in the org\n", numEntities)
-	clilog.Info.Printf("Exporting targetservers with %d connections\n", conn)
+	clilog.Info.Printf("Found %d targetservers in the org\n", len(targetservers))
+	clilog.Info.Printf("Exporting targetservers with %d parallel connections\n", conn)
 
-	numOfLoops, remaining := numEntities/conn, numEntities%conn
+	jobChan := make(chan string)
+	resultChan := make(chan []byte)
+	errChan := make(chan error)
 
-	//ensure connections aren't greater than targetservers
-	if conn > numEntities {
-		conn = numEntities
+	fanOutWg := sync.WaitGroup{}
+	fanInWg := sync.WaitGroup{}
+
+	errs := []string{}
+	fanInWg.Add(1)
+	go func() {
+		defer fanInWg.Done()
+		for {
+			newErr, ok := <-errChan
+			if !ok {
+				return
+			}
+			errs = append(errs, newErr.Error())
+		}
+	}()
+
+	results := [][]byte{}
+	fanInWg.Add(1)
+	go func() {
+		defer fanInWg.Done()
+		for {
+			newResult, ok := <-resultChan
+			if !ok {
+				return
+			}
+			results = append(results, newResult)
+		}
+	}()
+
+	for i := 0; i < conn; i++ {
+		fanOutWg.Add(1)
+		go exportServers(&fanOutWg, jobChan, resultChan, errChan)
 	}
 
-	start := 0
-
-	for i, end := 0, 0; i < numOfLoops; i++ {
-		pwg.Add(1)
-		end = (i * conn) + conn
-		clilog.Info.Printf("Exporting batch %d of targetservers\n", (i + 1))
-		go batchExport(targetservers[start:end], entityType, &pwg, &mu)
-		start = end
-		pwg.Wait()
+	for _, ts := range targetservers {
+		jobChan <- ts
 	}
+	close(jobChan)
+	fanOutWg.Wait()
+	close(errChan)
+	close(resultChan)
+	fanInWg.Wait()
 
-	if remaining > 0 {
-		pwg.Add(1)
-		clilog.Info.Printf("Exporting remaining %d targetservers\n", remaining)
-		go batchExport(targetservers[start:numEntities], entityType, &pwg, &mu)
-		pwg.Wait()
+	if len(errs) > 0 {
+		return nil, errors.New(strings.Join(errs, "\n"))
 	}
-
-	payload = make([][]byte, len(apiclient.GetEntityPayloadList()))
-	copy(payload, apiclient.GetEntityPayloadList())
-	apiclient.ClearEntityPayloadList()
-	return payload, nil
+	return results, nil
 }
 
-// batch created a batch of targetservers to query
-func batchExport(entities []string, entityType string, pwg *sync.WaitGroup, mu *sync.Mutex) {
-
-	defer pwg.Done()
-	//batch workgroup
-	var bwg sync.WaitGroup
-
-	bwg.Add(len(entities))
-
-	for _, entity := range entities {
+func exportServers(wg *sync.WaitGroup, jobs <-chan string, results chan<- []byte, errs chan<- error) {
+	defer wg.Done()
+	for {
+		job, ok := <-jobs
+		if !ok {
+			return
+		}
 		u, _ := url.Parse(apiclient.BaseURL)
-		u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "environments", apiclient.GetApigeeEnv(), entityType, entity)
-		go apiclient.GetAsyncEntity(u.String(), &bwg, mu)
+		u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "environments", apiclient.GetApigeeEnv(), "targetservers", job)
+		respBody, err := apiclient.HttpClient(false, u.String())
+		if err != nil {
+			errs <- err
+		} else {
+			results <- respBody
+		}
 	}
-	bwg.Wait()
 }
 
 // Import
 func Import(conn int, filePath string) (err error) {
-	var pwg sync.WaitGroup
-	const entityType = "targetservers"
-
-	u, _ := url.Parse(apiclient.BaseURL)
-	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "environments", apiclient.GetApigeeEnv(), entityType)
-
-	entities, err := readTargetServersFile(filePath)
+	targetservers, err := readTargetServersFile(filePath)
 	if err != nil {
 		clilog.Error.Println("Error reading file: ", err)
 		return err
 	}
 
-	numEntities := len(entities)
-	clilog.Info.Printf("Found %d target servers in the file\n", numEntities)
+	clilog.Info.Printf("Found %d target servers in the file\n", len(targetservers))
 	clilog.Info.Printf("Create target servers with %d connections\n", conn)
 
-	numOfLoops, remaining := numEntities/conn, numEntities%conn
+	jobChan := make(chan targetserver)
+	errChan := make(chan error)
 
-	//ensure connections aren't greater than entities
-	if conn > numEntities {
-		conn = numEntities
+	fanOutWg := sync.WaitGroup{}
+	fanInWg := sync.WaitGroup{}
+
+	errs := []string{}
+	fanInWg.Add(1)
+	go func() {
+		defer fanInWg.Done()
+		for {
+			newErr, ok := <-errChan
+			if !ok {
+				return
+			}
+			errs = append(errs, newErr.Error())
+		}
+	}()
+
+	for i := 0; i < conn; i++ {
+		fanOutWg.Add(1)
+		go importServers(&fanOutWg, jobChan, errChan)
 	}
 
-	start := 0
-
-	for i, end := 0, 0; i < numOfLoops; i++ {
-		pwg.Add(1)
-		end = (i * conn) + conn
-		clilog.Info.Printf("Creating batch %d of target servers\n", (i + 1))
-		go batchImport(u.String(), entities[start:end], &pwg)
-		start = end
-		pwg.Wait()
+	for _, ts := range targetservers {
+		jobChan <- ts
 	}
+	close(jobChan)
+	fanOutWg.Wait()
+	close(errChan)
+	fanInWg.Wait()
 
-	if remaining > 0 {
-		pwg.Add(1)
-		clilog.Info.Printf("Creating remaining %d target servers\n", remaining)
-		go batchImport(u.String(), entities[start:numEntities], &pwg)
-		pwg.Wait()
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n"))
 	}
-
 	return nil
 }
 
 // batch creates a batch of target servers to create
-func batchImport(url string, entities []targetserver, pwg *sync.WaitGroup) {
-
-	defer pwg.Done()
-	//batch workgroup
-	var bwg sync.WaitGroup
-
-	bwg.Add(len(entities))
-
-	for _, entity := range entities {
-		go createAsyncTargetServer(url, entity, &bwg)
-	}
-	bwg.Wait()
-}
-
-func createAsyncTargetServer(url string, entity targetserver, wg *sync.WaitGroup) {
+func importServers(wg *sync.WaitGroup, jobs <-chan targetserver, errs chan<- error) {
 	defer wg.Done()
-	out, err := json.Marshal(entity)
-	if err != nil {
-		clilog.Error.Println(err)
-		return
+
+	u, _ := url.Parse(apiclient.BaseURL)
+	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "environments", apiclient.GetApigeeEnv(), "targetservers")
+	for {
+		job, ok := <-jobs
+		if !ok {
+			return
+		}
+		b, err := json.Marshal(job)
+		if err != nil {
+			errs <- err
+			continue
+		}
+		_, err = apiclient.HttpClient(apiclient.GetPrintOutput(), u.String(), string(b))
+		if err != nil {
+			errs <- err
+		}
+		clilog.Info.Printf("Completed targetserver: %s", job.Name)
 	}
-	_, err = apiclient.HttpClient(apiclient.GetPrintOutput(), url, string(out))
-	if err != nil {
-		clilog.Error.Println(err)
-		return
-	}
-	clilog.Info.Printf("Completed entity: %s", entity.Name)
 }
 
 func readTargetServersFile(filePath string) ([]targetserver, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
 
 	targetservers := []targetserver{}
-
-	jsonFile, err := os.Open(filePath)
-
+	err = json.Unmarshal(content, &targetservers)
 	if err != nil {
-		return targetservers, err
+		return nil, err
 	}
-
-	defer jsonFile.Close()
-
-	byteValue, err := io.ReadAll(jsonFile)
-
-	if err != nil {
-		return targetservers, err
-	}
-
-	err = json.Unmarshal(byteValue, &targetservers)
-
-	if err != nil {
-		return targetservers, err
-	}
-
 	return targetservers, nil
 }


### PR DESCRIPTION
Hello `apigeecli` maintainers.

First things first: thank you for putting together this command-line tool to facilitate interactions with our Apigee deployments! It's very helpful in building automated workflows.

On this specific Pull Request: as you may note it is a draft, as it is not intended to be merged as is without prior discussion.

While using the tool I realised that when importing / exporting certain resources such as targetservers an error may be thrown by the server side without this resulting in a non-zero exit code. Even though the error is still printed.

Example:
```text
$ apigeecli targetservers import --org=my-apigee-org --environment=dev --file=environments/dev/targetservers.json --token="$(gcloud auth login --print-access-token)"
ERROR: 2023/01/12 14:18:22 httpclient.go:381: status code 404, error in response: {
  "error": {
    "code": 404,
    "message": "Environment \"organizations/my-apigee-org/environments/dev\" not found",
    "status": "NOT_FOUND",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.RequestInfo",
        "requestId": "17271276888273507243"
      }
    ]
  }
}
$ echo $?
0
```

I've traced this back to the import / export logic itself and realised that it currently uses non-standard parallelism patterns that prevent the errors from being appropriately reported through a non zero-exit code. Instead the errors are only printed without influencing the actual program's termination.

At the same time I also realised that due to the way Go routines are being created is rather convoluted which leads to a hard-to-grasp parallel processing setup.

In my book these are two bugs that could use some squashing. :)

Given that I have some Go knowledge of my own I've put together this Pull Request to showcase how the import / export logic may be modified to properly return any errors. It also shows how some other standard Go patterns (fan-out/fan-in through channels) can be used to simplify the concurrency setup.

Please let me know what you think. If the solution seems useful & acceptable to you I'd be happy to merge the Pull Request and raise a few follow-up ones that use identical fixes in other places of the codebase where these error-reporting and parallelism bugs appear.