### PR TITLE
Change Base Path check in `apis create bundle` to support Windows OS

### DIFF
--- a/cmd/apis/bundlecrtapis.go
+++ b/cmd/apis/bundlecrtapis.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/apigee/apigeecli/apiclient"
 	proxybundle "github.com/apigee/apigeecli/bundlegen/proxybundle"
@@ -51,7 +52,7 @@ var BundleCreateCmd = &cobra.Command{
 			if stat, err := os.Stat(folder); err == nil && !stat.IsDir() {
 				return fmt.Errorf("supplied path is not a folder")
 			}
-			if path.Base(proxyFolder) != "apiproxy" {
+			if filepath.Base(proxyFolder) != "apiproxy" {
 				return fmt.Errorf("--proxy-folder or -p must be a path to apiproxy folder")
 			}
 			tmpDir, err := os.MkdirTemp("", "proxy")


### PR DESCRIPTION
Change `path.Base` to `filepath.Base` in `apis create bundle` in order to support Windows OS.
The Golang [path/filepath](https://pkg.go.dev/path/filepath) should be used used for OS independent path checking.
Fixes https://github.com/apigee/apigeecli/issues/162.
