### PR TITLE
fix: add release version tag back to name format for assets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 # .goreleaser.yml
 project_name: apigeecli
 
@@ -30,12 +29,12 @@ builds:
       - darwin
       - windows
     flags:
-    - -trimpath
-    - -buildvcs=true
+      - -trimpath
+      - -buildvcs=true
     ldflags:
       - -s -w -extldflags "-static" -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
     gcflags:
-    - all="-l"
+      - all="-l"
     env:
       - CGO_ENABLED=0
     goarch:
@@ -52,6 +51,7 @@ archives:
     format: zip
     name_template: >-
       {{ .ProjectName }}_
+      {{- .Tag }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "linux" }}Linux
@@ -66,11 +66,10 @@ archives:
       - apigeecli
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 signs:
-  -
-    artifacts: all
+  - artifacts: all
     args:
       [
         "-u",
@@ -85,7 +84,7 @@ changelog:
   sort: asc
   use: github
   groups:
-    - title: 'Change Log'
+    - title: "Change Log"
       order: 0
 
 release:

--- a/downloadLatest.sh
+++ b/downloadLatest.sh
@@ -65,7 +65,7 @@ tmp=$(mktemp -d /tmp/apigeecli.XXXXXX)
 NAME="apigeecli_$APIGEECLI_VERSION"
 
 cd "$tmp" || exit
-URL="https://github.com/apigee/apigeecli/releases/download/${APIGEECLI_VERSION}/apigeecli_${OSEXT}_${APIGEECLI_ARCH}.zip"
+URL="https://github.com/apigee/apigeecli/releases/download/${APIGEECLI_VERSION}/apigeecli_${APIGEECLI_VERSION}_${OSEXT}_${APIGEECLI_ARCH}.zip"
 
 download_cli() {
   printf "\nDownloading %s from %s ...\n" "$NAME" "$URL"
@@ -74,7 +74,7 @@ download_cli() {
     exit 1
   fi
   curl -fsLO "$URL"
-  filename="apigeecli_${OSEXT}_${APIGEECLI_ARCH}.zip"
+  filename="apigeecli_${APIGEECLI_VERSION}_${OSEXT}_${APIGEECLI_ARCH}.zip"
   unzip "${filename}"
   rm "${filename}"
 }
@@ -91,8 +91,8 @@ printf "\n"
 # setup apigeecli
 cd "$HOME" || exit
 mkdir -p "$HOME/.apigeecli/bin"
-mv "${tmp}/apigeecli_${OSEXT}_${APIGEECLI_ARCH}/apigeecli" "$HOME/.apigeecli/bin"
-mv "${tmp}/apigeecli_${OSEXT}_${APIGEECLI_ARCH}/LICENSE.txt" "$HOME/.apigeecli/LICENSE.txt"
+mv "${tmp}/apigeecli_${APIGEECLI_VERSION}_${OSEXT}_${APIGEECLI_ARCH}/apigeecli" "$HOME/.apigeecli/bin"
+mv "${tmp}/apigeecli_${APIGEECLI_VERSION}_${OSEXT}_${APIGEECLI_ARCH}/LICENSE.txt" "$HOME/.apigeecli/LICENSE.txt"
 
 printf "Copied apigeecli into the $HOME/.apigeecli/bin folder.\n"
 chmod +x "$HOME/.apigeecli/bin/apigeecli"


### PR DESCRIPTION
Release version was removed from Asset name after updating `.goreleaser.yml`. 
Adding this back to maintain a consistent naming convention for release artifacts. 

Revert changes to `downloadLatest.sh` as these are no longer required if the version remains in the asset filename.

Discussed in https://github.com/apigee/apigeecli/issues/195

