### PR TITLE
exclude emacs backup files from generated bundles

### DIFF
--- a/internal/bundlegen/proxybundle/proxybundle.go
+++ b/internal/bundlegen/proxybundle/proxybundle.go
@@ -566,6 +566,9 @@ func archiveBundle(pathToZip, destinationPath string) (err error) {
 		if err != nil {
 			return err
 		}
+		if strings.HasSuffix(filePath, "~") {
+			return nil
+		}
 		relPath := filepath.ToSlash(strings.TrimPrefix(filePath, filepath.Dir(pathToZip)))
 		zipEntry := strings.TrimPrefix(relPath, pathSep)
 		zipFile, err := myZip.Create(zipEntry)


### PR DESCRIPTION
function archiveBundle() includes all files into the bundle. But emacs leaves file.xml~ files around. When such unrecognized files are included in the bundle, the control plane validator rejects the zip.  This change just skips those backup files.  