### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN go mod download
 RUN date +%FT%H:%I:%M+%Z > /tmp/date
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=true -a -gcflags='all="-l"' -ldflags='-s -w -extldflags "-static" -X main.version='${TAG}' -X main.commit='${COMMIT}' -X main.date='$(cat /tmp/date) -o /go/bin/apigeecli /go/src/apigeecli/main.go
 
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/cloud-marketplace/google/debian11:latest
 COPY --from=builder /go/bin/apigeecli /
 COPY LICENSE.txt /
 COPY third-party-licenses.txt /


### PR DESCRIPTION
Can we use an image that supports a shell session? I'd like to use the container with gitlab but they require shell scripts to be executed: https://docs.gitlab.com/ee/ci/docker/using_docker_images.html