### PR TITLE
fix: apply default revision when creating debugsession

### DIFF
--- a/internal/cmd/apis/crttrcapi.go
+++ b/internal/cmd/apis/crttrcapi.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020,2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,11 @@ var CreateTrcCmd = &cobra.Command{
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		if revision == -1 {
+			if revision, err = apis.GetHighestProxyRevision(name); err != nil {
+				return err
+			}
+		}
 		_, err = apis.CreateTraceSession(name, revision, filter)
 		return
 	},
@@ -44,10 +49,10 @@ func init() {
 	CreateTrcCmd.Flags().StringVarP(&name, "name", "n",
 		"", "API proxy name")
 	CreateTrcCmd.Flags().IntVarP(&revision, "rev", "v",
-		-1, "API Proxy revision")
+		-1, "API Proxy revision. If not set, the highest revision is used")
 	CreateTrcCmd.Flags().StringToStringVar(&filter, "filter",
 		nil, "Filter Conditions; format is name1=value1,name2=value2...")
 
 	_ = CreateTrcCmd.MarkFlagRequired("name")
-	_ = CreateTrcCmd.MarkFlagRequired("rev")
+	//_ = CreateTrcCmd.MarkFlagRequired("rev")
 }

--- a/internal/cmd/apis/crttrcapi.go
+++ b/internal/cmd/apis/crttrcapi.go
@@ -54,5 +54,4 @@ func init() {
 		nil, "Filter Conditions; format is name1=value1,name2=value2...")
 
 	_ = CreateTrcCmd.MarkFlagRequired("name")
-	//_ = CreateTrcCmd.MarkFlagRequired("rev")
 }

--- a/internal/cmd/apis/gettrcapi.go
+++ b/internal/cmd/apis/gettrcapi.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ func init() {
 	GetTrcCmd.Flags().StringVarP(&name, "name", "n",
 		"", "API proxy name")
 	GetTrcCmd.Flags().IntVarP(&revision, "rev", "v",
-		-1, "API Proxy revision")
+		-1, "API Proxy revision. If not set, the highest revision is used")
 	GetTrcCmd.Flags().StringVarP(&sessionID, "ses", "s",
 		"", "Debug session Id")
 	GetTrcCmd.Flags().StringVarP(&messageID, "msg", "m",

--- a/internal/cmd/apis/gettrcapi.go
+++ b/internal/cmd/apis/gettrcapi.go
@@ -53,7 +53,7 @@ func init() {
 	GetTrcCmd.Flags().StringVarP(&sessionID, "ses", "s",
 		"", "Debug session Id")
 	GetTrcCmd.Flags().StringVarP(&messageID, "msg", "m",
-		"", "Debug session Id")
+		"", "Debug transaction Id")
 
 	_ = GetTrcCmd.MarkFlagRequired("name")
 	_ = GetTrcCmd.MarkFlagRequired("ses")

--- a/internal/cmd/apis/gettrcapi.go
+++ b/internal/cmd/apis/gettrcapi.go
@@ -33,6 +33,11 @@ var GetTrcCmd = &cobra.Command{
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		if revision == -1 {
+			if revision, err = apis.GetHighestProxyRevision(name); err != nil {
+				return err
+			}
+		}
 		_, err = apis.GetTraceSession(name, revision, sessionID, messageID)
 		return
 	},
@@ -51,6 +56,5 @@ func init() {
 		"", "Debug session Id")
 
 	_ = GetTrcCmd.MarkFlagRequired("name")
-	_ = GetTrcCmd.MarkFlagRequired("rev")
 	_ = GetTrcCmd.MarkFlagRequired("ses")
 }

--- a/internal/cmd/apis/undepapi.go
+++ b/internal/cmd/apis/undepapi.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020,2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,11 +51,10 @@ func init() {
 	UndepCmd.Flags().StringVarP(&env, "env", "e",
 		"", "Apigee environment name")
 	UndepCmd.Flags().IntVarP(&revision, "rev", "v",
-		-1, "API Proxy revision")
+		-1, "API Proxy revision. If not set, the highest revision is used")
 	UndepCmd.Flags().BoolVarP(&safeUndeploy, "safeundeploy", "",
 		true, deploymentMsg)
 
 	_ = UndepCmd.MarkFlagRequired("env")
 	_ = UndepCmd.MarkFlagRequired("name")
-	_ = UndepCmd.MarkFlagRequired("rev")
 }


### PR DESCRIPTION
The helpfile for creating a debugsession
```
   apigeecli apis debugsessions create --help
```
...states that the revision will default to "-1".  This is true but not helpful, as the `--rev` option is marked as required. Therefore this command won't succeed:
```
apigeecli apis debugsessions create --name $APIPROXY --env $ENV
```

This change actually uses the latest revision when no `--rev` flag is present.  

Also a similar change for the apis/debugsessions/get command:
```
apigeecli apis debugsessions get --ses ${SESSIONID} --name $APIPROXY --env $ENV
```

And for the apis/undeploy command:
```
apigeecli apis undeploy --name $APIPROXY --env $ENV
```
