### PR TITLE
fix: mark --display-name required in crtprod.go

### DIFF
--- a/internal/cmd/products/crtprod.go
+++ b/internal/cmd/products/crtprod.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,6 +70,25 @@ var CreateCmd = &cobra.Command{
 
 		return err
 	},
+	Example: `Create an API product, using externally defined operations, with auto approval and access=public:
+  apigeecli products create --name "$product_name" \
+		--display-name "$product_name" \
+		--opgrp "$ops_file" \
+		--envs "$env" \
+		--approval auto \
+		--attrs access=public \
+		--token $TOKEN
+
+Create an API product, using externally defined operations, with auto approval and access=public, and a quota of 100/minute:
+  apigeecli products create --name "$product_name" \
+		--display-name "$product_name" \
+		--opgrp "$ops_file" \
+		--envs "$env" \
+		--approval auto \
+		--attrs access=public \
+		--quota 100 --interval 1 --unit minute \
+		--token $TOKEN
+`,
 }
 
 var operationGroupFile, gqlOperationGroupFile, grpcOperationGroupFile, quotaCounterScope string
@@ -108,5 +127,6 @@ func init() {
 	// TODO: apiresource -r later
 
 	_ = CreateCmd.MarkFlagRequired("name")
+	_ = CreateCmd.MarkFlagRequired("display-name")
 	_ = CreateCmd.MarkFlagRequired("approval")
 }


### PR DESCRIPTION
also add two example invocations for the command.

```
$  ./apigeecli products create  --help       
Create an API product

Usage:
  apigeecli products create [flags]

Examples:
Create an API product, using externally defined operations, with auto approval and access=public:
  apigeecli products create --name "$product_name" \
		--display-name "$product_name" \
		--opgrp "$ops_file" \
		--envs "$env" \
		--approval auto \
		--attrs access=public \
		--token $TOKEN

Create an API product, using externally defined operations, with auto approval and access=public, and a quota of 100/minute:
  apigeecli products create --name "$product_name" \
		--display-name "$product_name" \
		--opgrp "$ops_file" \
		--envs "$env" \
		--approval auto \
		--attrs access=public \
		--quota 100 --interval 1 --unit minute \
		--token $TOKEN


Flags:
...
```