### PR TITLE
APIGEECLI_ARCH should be arm64 if LOCAL_ARCH is arm64

### DIFF
--- a/downloadLatest.sh
+++ b/downloadLatest.sh
@@ -35,10 +35,10 @@ if [ "${TARGET_ARCH}" ]; then
 fi
 
 case "${LOCAL_ARCH}" in
-  x86_64|amd64|arm64)
+  x86_64|amd64)
     APIGEECLI_ARCH=x86_64
     ;;
-  armv8*|aarch64*)
+  arm64|armv8*|aarch64*)
     APIGEECLI_ARCH=arm64
     ;;
   *)


### PR DESCRIPTION
Currently if `LOCAL_ARCH` is `arm64`, then `APIGEECLI_ARCH` is set to `x86_64`, which at least for me cause the wrong binary to be installed.