### PR TITLE
bug: fix sharedflow deploy error exit status code #644

### DIFF
--- a/internal/cmd/sharedflows/common.go
+++ b/internal/cmd/sharedflows/common.go
@@ -65,6 +65,7 @@ func Wait(name string, revision int) error {
 			clilog.Info.Println("Sharedflow deployment completed with status: ", respMap["state"])
 		default:
 			clilog.Info.Println("Sharedflow deployment failed with status: ", respMap["state"])
+			err = fmt.Errorf("Sharedflow deployment failed with status: %s", respMap["state"])
 		}
 		return false
 	})

--- a/internal/cmd/sharedflows/depsf.go
+++ b/internal/cmd/sharedflows/depsf.go
@@ -39,8 +39,12 @@ var DepCmd = &cobra.Command{
 				return err
 			}
 		}
-		_, err = sharedflows.Deploy(name, revision, overrides, serviceAccountName)
-		apiclient.DisableCmdPrintHttpResponse()
+		if _, err = sharedflows.Deploy(name,
+			revision,
+			overrides,
+			serviceAccountName); err != nil {
+			return err
+		}
 
 		if wait {
 			err = Wait(name, revision)


### PR DESCRIPTION
Reproduced by forcing a JS syntax error in sharedflow, then tried to deploy, which failed.

Exit status code correctly returns "1".