### PR TITLE
Maximum page size of apps is 1000, not 10000.

### DIFF
--- a/internal/client/apps/apps.go
+++ b/internal/client/apps/apps.go
@@ -583,7 +583,7 @@ func listAllApps() (appList apps, err error) {
 		if startKey != "" {
 			q := u.Query()
 			q.Set("startKey", startKey)
-			q.Set("rows", "10000")
+			q.Set("rows", "1000")
 			u.RawQuery = q.Encode()
 		}
 
@@ -600,9 +600,9 @@ func listAllApps() (appList apps, err error) {
 
 		appList.Apps = append(appList.Apps, a.Apps...)
 
-		if len(a.Apps) == 10000 {
+		if len(a.Apps) == 1000 {
 			startKey = a.Apps[len(a.Apps)-1].AppID
-		} else if len(a.Apps) < 10000 {
+		} else if len(a.Apps) < 1000 {
 			break
 		}
 	}


### PR DESCRIPTION
Fix Issue https://github.com/apigee/apigeecli/issues/669. 
The apps list API has a maximum page size of 1000, not the documented 10000. 
Using 10000 will result in only exporting 1000 apps when more then 1000 exist.