### PR TITLE
FIX: Some commands were not using supplied region.

### DIFF
--- a/internal/cmd/appgroups/manage.go
+++ b/internal/cmd/appgroups/manage.go
@@ -27,6 +27,7 @@ var ManageCmd = &cobra.Command{
 	Short: "Approve or revoke an AppGroup",
 	Long:  "Approve or revoke an AppGroup",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/listenv.go
+++ b/internal/cmd/env/listenv.go
@@ -27,6 +27,7 @@ var ListCmd = &cobra.Command{
 	Short: "List environments in an Apigee Org",
 	Long:  "List environments in an Apigee Org",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/listsecact.go
+++ b/internal/cmd/env/listsecact.go
@@ -28,6 +28,7 @@ var ListSecActCmd = &cobra.Command{
 	Long:  "Returns security actions in the environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/listsecin.go
+++ b/internal/cmd/env/listsecin.go
@@ -28,6 +28,7 @@ var ListSecInCmd = &cobra.Command{
 	Long:  "Returns security incidents in the environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/listsecreports.go
+++ b/internal/cmd/env/listsecreports.go
@@ -28,6 +28,7 @@ var ListSecReportCmd = &cobra.Command{
 	Long:  "Returns a security reports by name",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/listtraceoverrides.go
+++ b/internal/cmd/env/listtraceoverrides.go
@@ -29,6 +29,7 @@ var ListTraceOverridesCmd = &cobra.Command{
 	Long:  "List Distributed Trace config overrides",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/removerole.go
+++ b/internal/cmd/env/removerole.go
@@ -30,6 +30,7 @@ var RemoveRoleCmd = &cobra.Command{
 	Long:  "Remove a member or SA from a role for an environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/setadmin.go
+++ b/internal/cmd/env/setadmin.go
@@ -30,6 +30,7 @@ var SetAdminCmd = &cobra.Command{
 	Long:  "Set Environment Admin role for a member an Environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/setax.go
+++ b/internal/cmd/env/setax.go
@@ -34,6 +34,7 @@ var SetAxCmd = &cobra.Command{
 			return fmt.Errorf("invalid memberRole. Member role must be analyticsViewer or analyticsAgent")
 		}
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/setcustom.go
+++ b/internal/cmd/env/setcustom.go
@@ -32,6 +32,7 @@ var SetCustCmd = &cobra.Command{
 	Long:  "Set a custom role for a member on an environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/setdebugmask.go
+++ b/internal/cmd/env/setdebugmask.go
@@ -30,6 +30,7 @@ var SetDebugCmd = &cobra.Command{
 	Long:  "Set debugmasks for an Environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/setdeploy.go
+++ b/internal/cmd/env/setdeploy.go
@@ -30,6 +30,7 @@ var SetDepCmd = &cobra.Command{
 	Long:  "Set Apigee Deployer role for a member on an environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/setprop.go
+++ b/internal/cmd/env/setprop.go
@@ -28,6 +28,7 @@ var PropCmd = &cobra.Command{
 	Long:  "Set environment property",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/setsync.go
+++ b/internal/cmd/env/setsync.go
@@ -30,6 +30,7 @@ var SetSyncCmd = &cobra.Command{
 	Long:  "Set Synchronization Manager role for a member on an environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/testiam.go
+++ b/internal/cmd/env/testiam.go
@@ -29,6 +29,7 @@ var TestIamCmd = &cobra.Command{
 	Long:  "Test IAM policy for an Environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/env/updatetracecfg.go
+++ b/internal/cmd/env/updatetracecfg.go
@@ -29,6 +29,7 @@ var UpdateTraceConfigCmd = &cobra.Command{
 	Long:  "Update Distributed Trace config for the environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(environment)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/references/crtref.go
+++ b/internal/cmd/references/crtref.go
@@ -32,7 +32,7 @@ var CreateCmd = &cobra.Command{
 			return fmt.Errorf("resourceType should be KeyStore or TrustStore")
 		}
 		apiclient.SetApigeeEnv(env)
-
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/references/delref.go
+++ b/internal/cmd/references/delref.go
@@ -28,6 +28,7 @@ var DelCmd = &cobra.Command{
 	Long:  "Delete a reference in an environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(env)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/references/expref.go
+++ b/internal/cmd/references/expref.go
@@ -28,6 +28,7 @@ var ExpCmd = &cobra.Command{
 	Long:  "Export Environment References",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(env)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/references/getref.go
+++ b/internal/cmd/references/getref.go
@@ -28,6 +28,7 @@ var GetCmd = &cobra.Command{
 	Long:  "Get a reference in an environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(env)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/references/impref.go
+++ b/internal/cmd/references/impref.go
@@ -30,6 +30,7 @@ var ImpCmd = &cobra.Command{
 ` + GetExample(0),
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(env)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/references/listref.go
+++ b/internal/cmd/references/listref.go
@@ -28,6 +28,7 @@ var ListCmd = &cobra.Command{
 	Long:  "List all references in an environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		apiclient.SetApigeeEnv(env)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/references/updateref.go
+++ b/internal/cmd/references/updateref.go
@@ -32,6 +32,7 @@ var UpdateCmd = &cobra.Command{
 			return fmt.Errorf("resourceType should be KeyStore or TrustStore")
 		}
 		apiclient.SetApigeeEnv(env)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/cmd/sharedflows/delsf.go
+++ b/internal/cmd/sharedflows/delsf.go
@@ -28,8 +28,8 @@ var DelCmd = &cobra.Command{
 	Long: "Deletes a shared flow and all associated policies, resources, and revisions." +
 		"The flow must be undeployed first.",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
-		apiclient.SetRegion(region)
 		apiclient.SetApigeeEnv(env)
+		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {


### PR DESCRIPTION
Running

  apigeecli environments list -r us -o my-org

incorrectly snet requests to apigee.googleapis.com rather then us-apigee.googleapis.com.

This commit corrects that and the other commands that were not configuring the region in the apiclient.