### PR TITLE
Fix launch.json for debugging to use the VSCode workspace

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "./cmd/apigeecli/apigeecli.go",
+            "program": "${workspaceFolder}/cmd/apigeecli/apigeecli.go",
             // please change these args before debugging. do not checkin changes.
             "args": [
                 "apis",


### PR DESCRIPTION
Not providing the workspace will result in the debugger failing to launch on some systems due to how the current working directory is resolved. In my case, I had to alter this to be able to attach delve via VSCode.