### PR TITLE
GH-676: Fix nil pointer panic when setting an HTTP proxy

### DIFF
--- a/internal/apiclient/httpclient.go
+++ b/internal/apiclient/httpclient.go
@@ -395,7 +395,7 @@ func GetHttpClient() (err error) {
 	}
 
 	if GetProxyURL() != "" {
-		if proxyUrl, err := url.Parse(GetProxyURL()); err != nil {
+		if proxyUrl, err := url.Parse(GetProxyURL()); err == nil {
 			ApigeeAPIClient = &RateLimitedHTTPClient{
 				client: &http.Client{
 					Transport: &http.Transport{


### PR DESCRIPTION
Addresses a logic error in internal/apiclient/httpclient.go that would only attempt to  construct an `ApigeeAPIClient` with an HTTP proxy if the previous operation that attempts to parse the proxy URL failed.

This bug results in the API client singleton never being created when the proxy URL is valid, and the singleton is only created if the proxy is unset or has an invalid value. When using a proxy, this issue bubbles up and results in a nil-pointer dereference on the global API client singleton, which crashes the runtime.

Inverting the condition addresses this issue.

Can confirm proxies work as expected once this change is made.

Fixes GH-676.