### PR TITLE
fix: for #686

### DIFF
--- a/internal/client/hub/hub.go
+++ b/internal/client/hub/hub.go
@@ -695,7 +695,7 @@ func ListDeployments(filter string, pageSize int, pageToken string) (respBody []
 	return list("deployments", filter, pageSize, pageToken)
 }
 
-func UpdateDeployment(deploymentName string, displayName string, description string,
+func UpdateDeployment(deploymentID string, displayName string, description string,
 	externalURI string, resourceURI string, endpoints []string, dep DeploymentType,
 	env EnvironmentType, slo SloType,
 ) (respBody []byte, err error) {
@@ -730,12 +730,12 @@ func UpdateDeployment(deploymentName string, displayName string, description str
 	}
 
 	u, _ := url.Parse(apiclient.GetApigeeRegistryURL())
-	u.Path = path.Join(u.Path, "deployments", deploymentName)
+	u.Path = path.Join(u.Path, "deployments", deploymentID)
 	q := u.Query()
 	q.Set("updateMask", strings.Join(updateMask, ","))
 	u.RawQuery = q.Encode()
 
-	payload, err := getDeployment(displayName, description, deploymentName,
+	payload, err := getDeployment(displayName, description, deploymentID,
 		externalURI, resourceURI, endpoints, dep, env, slo)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/apihub/deployments/create.go
+++ b/internal/cmd/apihub/deployments/create.go
@@ -66,7 +66,6 @@ func init() {
 	CrtCmd.Flags().Var(&e, "env-type", "The environment mapping to this deployment")
 	CrtCmd.Flags().Var(&s, "slo-type", "The SLO for this deployment")
 
-	_ = CrtCmd.MarkFlagRequired("name")
 	_ = CrtCmd.MarkFlagRequired("display-name")
 	_ = CrtCmd.MarkFlagRequired("resource-uri")
 	_ = CrtCmd.MarkFlagRequired("endpoints")

--- a/internal/cmd/apihub/deployments/deployments.go
+++ b/internal/cmd/apihub/deployments/deployments.go
@@ -28,7 +28,7 @@ var DeploymentCmd = &cobra.Command{
 var org, region string
 
 var examples = []string{
-	`apigeecli apihub deployments create -n $name --dep-type apigee -d $dispName \
+	`apigeecli apihub deployments create --dep-type apigee -d $dispName \
 	--env-type development --slo-type "99-99" --endpoints https://api.example.com \
 	--resource-uri https://apigee.googleapis.com/v1/organizations/$project/apis/$proxy/revisions/1 \
 	-r us-central1 --default-token`,

--- a/internal/cmd/apihub/deployments/get.go
+++ b/internal/cmd/apihub/deployments/get.go
@@ -39,7 +39,7 @@ var GetCmd = &cobra.Command{
 
 func init() {
 	GetCmd.Flags().StringVarP(&deploymentID, "id", "i",
-		"", "Dependency ID")
+		"", "Deployment ID")
 
 	_ = GetCmd.MarkFlagRequired("id")
 }

--- a/internal/cmd/apihub/deployments/update.go
+++ b/internal/cmd/apihub/deployments/update.go
@@ -32,14 +32,14 @@ var UpdateCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
-		_, err = hub.UpdateDeployment(deploymentName, displayName, description, externalURI, resourceURI, endpoints, d, e, s)
+		_, err = hub.UpdateDeployment(deploymentID, displayName, description, externalURI, resourceURI, endpoints, d, e, s)
 		return
 	},
 }
 
 func init() {
-	UpdateCmd.Flags().StringVarP(&deploymentName, "id", "i",
-		"", "Deployment Name")
+	UpdateCmd.Flags().StringVarP(&deploymentID, "id", "i",
+		"", "Deployment ID")
 	UpdateCmd.Flags().StringVarP(&displayName, "display-name", "d",
 		"", "Deployment Display Name")
 	UpdateCmd.Flags().StringVarP(&description, "description", "",


### PR DESCRIPTION
- Rename `depoyments.go` to `deployments.go`
- Made the `--name` argument optional as its a required field in the API
- fixed typos 