### PR TITLE
GH-689: Mark products as optional when creating appgroup apps

### DIFF
--- a/internal/cmd/appgroups/crtapp.go
+++ b/internal/cmd/appgroups/crtapp.go
@@ -69,5 +69,4 @@ func init() {
 
 	_ = CreateAppCmd.MarkFlagRequired("name")
 	_ = CreateAppCmd.MarkFlagRequired("app-name")
-	_ = CreateAppCmd.MarkFlagRequired("prods")
 }


### PR DESCRIPTION
Fixes GH-689.