### PR TITLE
fix: apihub apis get with empty id #685

### DIFF
--- a/internal/cmd/apihub/apis/get.go
+++ b/internal/cmd/apihub/apis/get.go
@@ -15,6 +15,7 @@
 package apis
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/hub"
 
@@ -27,12 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Get details for an API",
 	Long:  "Get details for an API",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if apiID == "" {
+			return fmt.Errorf("id cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
-		_, err = hub.GetApi(apiID)
+
+		if apiID != "" {
+			_, err = hub.GetApi(apiID)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/apis/getapi.go
+++ b/internal/cmd/apis/getapi.go
@@ -15,6 +15,7 @@
 package apis
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/apis"
 
@@ -27,13 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Gets an API Proxy by name",
 	Long:  "Gets an API Proxy by name, including a list of its revisions.",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = apis.GetProxy(name, revision)
+		if name != "" {
+			_, err = apis.GetProxy(name, revision)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/appgroups/getapp.go
+++ b/internal/cmd/appgroups/getapp.go
@@ -15,6 +15,7 @@
 package appgroups
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/appgroups"
 
@@ -27,14 +28,20 @@ var GetAppCmd = &cobra.Command{
 	Short: "Get App in an AppGroup",
 	Long:  "Get App in an AppGroup",
 	Args: func(cmd *cobra.Command, args []string) error {
+		if name == "" || appName == "" {
+			return fmt.Errorf("name and app-name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = appgroups.GetApp(name, appName)
-		return err
+		if name != "" && appName != "" {
+			_, err = appgroups.GetApp(name, appName)
+			return err
+		}
+		return
 	},
 }
 

--- a/internal/cmd/appgroups/getappgroup.go
+++ b/internal/cmd/appgroups/getappgroup.go
@@ -15,6 +15,7 @@
 package appgroups
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/appgroups"
 
@@ -27,14 +28,20 @@ var GetCmd = &cobra.Command{
 	Short: "Get AppGroup in an Organization by AppGroup Name",
 	Long:  "Returns the app group details for the specified app group name",
 	Args: func(cmd *cobra.Command, args []string) error {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = appgroups.Get(name)
-		return err
+		if name != "" {
+			_, err = appgroups.Get(name)
+			return err
+		}
+		return
 	},
 }
 

--- a/internal/cmd/datacollectors/getdatacollector.go
+++ b/internal/cmd/datacollectors/getdatacollector.go
@@ -15,6 +15,7 @@
 package datacollectors
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/datacollectors"
 
@@ -27,13 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Get a Data Collector",
 	Long:  "Get a Data Collector",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = datacollectors.Get(name)
+		if name != "" {
+			_, err = datacollectors.Get(name)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/developers/getdev.go
+++ b/internal/cmd/developers/getdev.go
@@ -15,6 +15,7 @@
 package developers
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/developers"
 
@@ -27,13 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Returns the profile for a developer by email address or ID",
 	Long:  "Returns the profile for a developer by email address or ID",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if email == "" {
+			return fmt.Errorf("email cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = developers.Get(email)
+		if email != "" {
+			_, err = developers.Get(email)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/env/getenv.go
+++ b/internal/cmd/env/getenv.go
@@ -15,6 +15,7 @@
 package env
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/env"
 
@@ -27,6 +28,9 @@ var GetCmd = &cobra.Command{
 	Short: "Get properties of an environment",
 	Long:  "Get properties of an environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if environment == "" {
+			return fmt.Errorf("env cannot be empty")
+		}
 		apiclient.SetApigeeEnv(environment)
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
@@ -34,7 +38,10 @@ var GetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = env.Get(config)
+		if environment != "" {
+			_, err = env.Get(config)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/eptattachment/geteptattachment.go
+++ b/internal/cmd/eptattachment/geteptattachment.go
@@ -15,6 +15,7 @@
 package eptattachment
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/eptattachment"
 
@@ -27,13 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Get a service endpoint",
 	Long:  "Get a service endpoint",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = eptattachment.Get(name)
+		if name != "" {
+			_, err = eptattachment.Get(name)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/flowhooks/getfh.go
+++ b/internal/cmd/flowhooks/getfh.go
@@ -15,6 +15,7 @@
 package flowhooks
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/flowhooks"
 
@@ -27,6 +28,9 @@ var GetCmd = &cobra.Command{
 	Short: "Get a flowhook",
 	Long:  "Get a flowhook",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetApigeeEnv(env)
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
@@ -34,7 +38,10 @@ var GetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = flowhooks.Get(name)
+		if name != "" {
+			_, err = flowhooks.Get(name)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/instances/getinstance.go
+++ b/internal/cmd/instances/getinstance.go
@@ -15,6 +15,7 @@
 package instances
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/instances"
 
@@ -27,13 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Get an Instance",
 	Long:  "Get an Instance",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = instances.Get(name)
+		if name != "" {
+			_, err = instances.Get(name)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/keyaliases/getka.go
+++ b/internal/cmd/keyaliases/getka.go
@@ -15,6 +15,7 @@
 package keyaliases
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/keyaliases"
 
@@ -27,6 +28,9 @@ var GetCmd = &cobra.Command{
 	Short: "Get a Key Alias",
 	Long:  "Get a Key Alias",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if keystoreName == "" || aliasName == "" {
+			return fmt.Errorf("key and alias cannot be empty")
+		}
 		apiclient.SetApigeeEnv(env)
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
@@ -34,7 +38,10 @@ var GetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = keyaliases.Get(keystoreName, aliasName)
+		if keystoreName != "" && aliasName != "" {
+			_, err = keyaliases.Get(keystoreName, aliasName)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/keystores/getks.go
+++ b/internal/cmd/keystores/getks.go
@@ -15,6 +15,7 @@
 package keystores
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/keystores"
 
@@ -27,6 +28,9 @@ var GetCmd = &cobra.Command{
 	Short: "Get a Key Store",
 	Long:  "Get a Key Store",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetApigeeEnv(env)
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
@@ -34,7 +38,10 @@ var GetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = keystores.Get(name)
+		if name != "" {
+			_, err = keystores.Get(name)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/ops/getops.go
+++ b/internal/cmd/ops/getops.go
@@ -15,6 +15,7 @@
 package ops
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/operations"
 
@@ -27,13 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Get operation of an org",
 	Long:  "Get operation of an org",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = operations.Get(name)
+		if name != "" {
+			_, err = operations.Get(name)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/products/getprod.go
+++ b/internal/cmd/products/getprod.go
@@ -15,6 +15,7 @@
 package products
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/products"
 
@@ -27,13 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Gets an API product from an organization",
 	Long:  "Gets an API product from an organization",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = products.Get(name)
+		if name != "" {
+			_, err = products.Get(name)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/references/getref.go
+++ b/internal/cmd/references/getref.go
@@ -15,6 +15,7 @@
 package references
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/references"
 
@@ -27,6 +28,9 @@ var GetCmd = &cobra.Command{
 	Short: "Get a reference in an environment",
 	Long:  "Get a reference in an environment",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetApigeeEnv(env)
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
@@ -34,7 +38,10 @@ var GetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = references.Get(name)
+		if name != "" {
+			_, err = references.Get(name)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/reports/getreport.go
+++ b/internal/cmd/reports/getreport.go
@@ -15,6 +15,7 @@
 package reports
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/reports"
 
@@ -27,14 +28,20 @@ var GetCmd = &cobra.Command{
 	Short: "Get details for a custom report",
 	Long:  "Get details for a custom report",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = reports.Get(name)
-		return err
+		if name != "" {
+			_, err = reports.Get(name)
+			return err
+		}
+		return
 	},
 }
 

--- a/internal/cmd/res/getres.go
+++ b/internal/cmd/res/getres.go
@@ -15,6 +15,7 @@
 package res
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/res"
 	"strings"
@@ -28,6 +29,9 @@ var GetCmd = &cobra.Command{
 	Short: "Get a resource file",
 	Long:  "Get a resource file",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetApigeeEnv(env)
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
@@ -35,7 +39,10 @@ var GetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		return res.Get(name, resType)
+		if name != "" {
+			return res.Get(name, resType)
+		}
+		return
 	},
 }
 

--- a/internal/cmd/securityprofiles/get.go
+++ b/internal/cmd/securityprofiles/get.go
@@ -15,6 +15,7 @@
 package securityprofiles
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/securityprofiles"
 
@@ -27,13 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Returns a security profile by name",
 	Long:  "Returns a security profile by name",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("kurt name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = securityprofiles.Get(name, revision)
+		if name != "" {
+			_, err = securityprofiles.Get(name, revision)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/sharedflows/getsf.go
+++ b/internal/cmd/sharedflows/getsf.go
@@ -15,6 +15,7 @@
 package sharedflows
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/sharedflows"
 
@@ -27,6 +28,9 @@ var GetCmd = &cobra.Command{
 	Short: "Gets a shared flow by name",
 	Long:  "Gets a shared flow by name, including a list of its revisions.",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetApigeeEnv(env)
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
@@ -34,7 +38,10 @@ var GetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = sharedflows.Get(name, revision)
+		if name != "" {
+			_, err = sharedflows.Get(name, revision)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/spaces/getspace.go
+++ b/internal/cmd/spaces/getspace.go
@@ -15,6 +15,7 @@
 package spaces
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/spaces"
 
@@ -27,13 +28,19 @@ var GetCmd = &cobra.Command{
 	Short: "Get an Apigee Space",
 	Long:  "Get an Apigee Space",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
 	},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = spaces.Get(name)
+		if name != "" {
+			_, err = spaces.Get(name)
+			return err
+		}
 		return
 	},
 }

--- a/internal/cmd/targetservers/getts.go
+++ b/internal/cmd/targetservers/getts.go
@@ -15,6 +15,7 @@
 package targetservers
 
 import (
+	"fmt"
 	"internal/apiclient"
 	"internal/client/targetservers"
 
@@ -27,6 +28,9 @@ var GetCmd = &cobra.Command{
 	Short: "Get a Target Server",
 	Long:  "Get a Target Server",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty")
+		}
 		apiclient.SetApigeeEnv(env)
 		apiclient.SetRegion(region)
 		return apiclient.SetApigeeOrg(org)
@@ -34,7 +38,10 @@ var GetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = targetservers.Get(name)
+		if name != "" {
+			_, err = targetservers.Get(name)
+			return err
+		}
 		return
 	},
 }


### PR DESCRIPTION
gorun --org=$ORG --region=us-central1  apihub apis get --id=""
Error: id cannot be empty
