### PR TITLE
fix: preserve app attributes when generating a new key

### DIFF
--- a/internal/client/apps/apps.go
+++ b/internal/client/apps/apps.go
@@ -261,6 +261,23 @@ func ListApps(productName string) (respBody []byte, err error) {
 func GenerateKey(name string, developerID string, apiProducts []string, callback string, expires string, scopes []string) (respBody []byte, err error) {
 	u, _ := url.Parse(apiclient.GetApigeeBaseURL())
 
+	// Fetch the existing app to preserve its attributes; the Apigee POST
+	// endpoint for key generation also updates the app, clearing any fields
+	// absent from the request body.
+	apiclient.ClientPrintHttpResponse.Set(false)
+	appURL, _ := url.Parse(apiclient.GetApigeeBaseURL())
+	appURL.Path = path.Join(appURL.Path, apiclient.GetApigeeOrg(), "developers", developerID, "apps", name)
+	existingAppBody, err := apiclient.HttpClient(appURL.String())
+	apiclient.ClientPrintHttpResponse.Set(apiclient.GetCmdPrintHttpResponseSetting())
+	if err != nil {
+		return nil, err
+	}
+
+	var existingApp application
+	if err = json.Unmarshal(existingAppBody, &existingApp); err != nil {
+		return nil, err
+	}
+
 	key := []string{}
 
 	key = append(key, "\"name\":\""+name+"\"")
@@ -276,6 +293,14 @@ func GenerateKey(name string, developerID string, apiProducts []string, callback
 
 	if len(scopes) > 0 {
 		key = append(key, "\"scopes\":[\""+getArrayStr(scopes)+"\"]")
+	}
+
+	if len(existingApp.Attributes) > 0 {
+		attributes := []string{}
+		for _, attr := range existingApp.Attributes {
+			attributes = append(attributes, "{\"name\":\""+attr.Name+"\",\"value\":\""+attr.Value+"\"}")
+		}
+		key = append(key, "\"attributes\":["+strings.Join(attributes, ",")+"]")
 	}
 
 	payload := "{" + strings.Join(key, ",") + "}"

--- a/internal/client/apps/apps.go
+++ b/internal/client/apps/apps.go
@@ -296,11 +296,11 @@ func GenerateKey(name string, developerID string, apiProducts []string, callback
 	}
 
 	if len(existingApp.Attributes) > 0 {
-		attributes := []string{}
-		for _, attr := range existingApp.Attributes {
-			attributes = append(attributes, "{\"name\":\""+attr.Name+"\",\"value\":\""+attr.Value+"\"}")
+		attrBytes, err := json.Marshal(existingApp.Attributes)
+		if err != nil {
+			return nil, err
 		}
-		key = append(key, "\"attributes\":["+strings.Join(attributes, ",")+"]")
+		key = append(key, "\"attributes\":"+string(attrBytes))
 	}
 
 	payload := "{" + strings.Join(key, ",") + "}"

--- a/internal/client/apps/apps_test.go
+++ b/internal/client/apps/apps_test.go
@@ -131,8 +131,18 @@ func TestGenerateKey(t *testing.T) {
 	expires := "-1"
 	callback := ""
 	scopes := []string{"test"}
-	if _, err := GenerateKey(name, devID, apiProducts, callback, expires, scopes); err != nil {
+	respBody, err := GenerateKey(name, devID, apiProducts, callback, expires, scopes)
+	if err != nil {
 		t.Fatalf("%v", err)
+	}
+
+	var respJSONMap map[string]interface{}
+	if err = json.Unmarshal(respBody, &respJSONMap); err != nil {
+		t.Fatalf("%v", err)
+	}
+	attrs, ok := respJSONMap["attributes"].([]interface{})
+	if !ok || len(attrs) == 0 {
+		t.Fatalf("expected app attributes to be preserved after genkey, got none")
 	}
 }
 

--- a/internal/client/apps/keys_test.go
+++ b/internal/client/apps/keys_test.go
@@ -52,7 +52,7 @@ func TestManageKey(t *testing.T) {
 		clienttest.SITEID_NOT_REQD, clienttest.CLIPATH_NOT_REQD); err != nil {
 		t.Fatalf("%v", err)
 	}
-	if _, err := ManageKey(name, appID, "key1", "approve"); err != nil {
+	if _, err := ManageKey(name, appID, "key1", "approve", ""); err != nil {
 		t.Fatalf("%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- `GenerateKey` was POSTing to `/developers/{dev}/apps/{name}` without including the app's existing attributes in the payload
- The Apigee API treats this endpoint as an app update in addition to key generation, so any field absent from the request body gets cleared
- Fix fetches the current app before the POST and re-includes its attributes in the payload

Fixes #651

## Test plan

- Updated `TestGenerateKey` in `internal/client/apps/apps_test.go` to assert that app attributes are present in the response after key generation
- Run against a real Apigee org: `go test -v -run TestGenerateKey ./...`