### PR TITLE
fix: upload OAS 3.1 spec to proxy bundle even when validate policy is skipped

### DIFF
--- a/internal/bundlegen/generateapiv2.go
+++ b/internal/bundlegen/generateapiv2.go
@@ -155,8 +155,9 @@ func GenerateAPIProxyDefFromOASv2(name string,
 
 	apiproxy.AddProxyEndpoint(DEFAULT)
 
+	// always declare the spec as a resource so it is bundled with the proxy
+	apiproxy.AddResource(oasDocName, "oas")
 	if !skipPolicy {
-		apiproxy.AddResource(oasDocName, "oas")
 		apiproxy.AddPolicy("Validate-" + name + "-Schema")
 	}
 

--- a/internal/bundlegen/generateapiv2_test.go
+++ b/internal/bundlegen/generateapiv2_test.go
@@ -36,7 +36,7 @@ func TestSpecs(t *testing.T) {
 	for _, specName := range specNames {
 		fmt.Println("Testing " + specName + " ...")
 		testLoadDocument(specName, t)
-		TestGenerateAPIProxyDefFromOASv2(specName, t)
+		testGenerateAPIProxyDefFromOASv2(specName, t)
 	}
 }
 
@@ -50,7 +50,7 @@ func testLoadDocument(specName string, t *testing.T) {
 	}
 }
 
-func TestGenerateAPIProxyDefFromOASv2(specName string, t *testing.T) {
+func testGenerateAPIProxyDefFromOASv2(specName string, t *testing.T) {
 	skipPolicy := false
 	name := "test"
 	desc := "Sample description"

--- a/internal/bundlegen/proxybundle/proxybundle.go
+++ b/internal/bundlegen/proxybundle/proxybundle.go
@@ -128,13 +128,12 @@ func GenerateAPIProxyBundleFromOAS(name string,
 		}
 	}
 
-	if !skipPolicy {
-		if err = os.MkdirAll(resDirPath, os.ModePerm); err != nil {
-			return err
-		}
-		if err = writeXMLData(resDirPath+string(os.PathSeparator)+fileName, content); err != nil {
-			return err
-		}
+	// always write the spec to the resources directory so it is bundled with the proxy
+	if err = os.MkdirAll(resDirPath, os.ModePerm); err != nil {
+		return err
+	}
+	if err = writeXMLData(resDirPath+string(os.PathSeparator)+fileName, content); err != nil {
+		return err
 	}
 
 	if err = os.Mkdir(policiesDirPath, os.ModePerm); err != nil {

--- a/internal/bundlegen/proxybundle/proxybundle_test.go
+++ b/internal/bundlegen/proxybundle/proxybundle_test.go
@@ -70,6 +70,7 @@ func TestGenerateAPIProxyBundleFromOAS(t *testing.T) {
 		},
 	}
 	if err := bundlegen.GenerateAPIProxyDefFromOASv2(name,
+		"",
 		basePath,
 		specName,
 		skipPolicy,

--- a/internal/cmd/apis/oascrtapisv2.go
+++ b/internal/cmd/apis/oascrtapisv2.go
@@ -85,7 +85,7 @@ Create an API Proxy from OAS and deploy the proxy to an environment:
 		if version != "" {
 			re := regexp.MustCompile(`3\.1\.[0-9]`)
 			if re.MatchString(version) {
-				clilog.Warning.Println("OpenAPI 3.1 detected. Skipping policy validation.")
+				clilog.Warning.Println("OpenAPI 3.1 detected. Skipping OAS Validate policy (not supported for 3.1); spec will still be uploaded to the proxy bundle.")
 				skipPolicy = true
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #640.

When an OpenAPI 3.1 spec is detected, the Apigee OAS Validate policy is correctly skipped (it does not support 3.1). However, a single `skipPolicy` flag was coupling two independent behaviors:

1. Writing the spec file to `apiproxy/resources/oas/`
2. Adding the `OpenAPI-Spec-Validation-1.xml` policy

This caused the spec to **not be uploaded** to the proxy bundle at all, even though users expect it to be present as a resource.

**Changes:**

- `internal/bundlegen/proxybundle/proxybundle.go` — always write the spec to `resources/oas/` regardless of `skipPolicy`; only the validate policy XML remains conditional
- `internal/bundlegen/generateapiv2.go` — always call `apiproxy.AddResource(oasDocName, "oas")` so the spec is declared in the proxy descriptor; `AddPolicy(...)` remains conditional
- `internal/cmd/apis/oascrtapisv2.go` — updated warning message to clarify that the spec *is* still uploaded; only the validate policy is skipped
- `internal/bundlegen/generateapiv2_test.go` — fixed pre-existing bug: renamed `TestGenerateAPIProxyDefFromOASv2` (had wrong `Test*` signature for a helper function) to `testGenerateAPIProxyDefFromOASv2`
- `internal/bundlegen/proxybundle/proxybundle_test.go` — fixed pre-existing bug: added missing `description` argument in the call to `GenerateAPIProxyDefFromOASv2`

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go vet` passes on all changed packages (verified locally)
- [ ] Run `apigeecli apis create oas` with an OAS 3.1 spec and confirm the spec appears in `apiproxy/resources/oas/` in the generated zip
- [ ] Run `apigeecli apis create oas` with an OAS 3.0 spec and confirm the validate policy and spec are both still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)