### PR TITLE
feat: add masked field support to KVM create/update (#715)

### DIFF
--- a/internal/client/kvm/kvm.go
+++ b/internal/client/kvm/kvm.go
@@ -23,13 +23,16 @@ import (
 )
 
 // Create
-func Create(proxyName string, name string, encrypt bool) (respBody []byte, err error) {
+func Create(proxyName string, name string, encrypt bool, masked bool) (respBody []byte, err error) {
 	u, _ := url.Parse(apiclient.GetApigeeBaseURL())
 	kvm := []string{}
 
 	kvm = append(kvm, "\"name\":\""+name+"\"")
 	if encrypt {
 		kvm = append(kvm, "\"encrypted\":"+strconv.FormatBool(encrypt))
+	}
+	if masked {
+		kvm = append(kvm, "\"masked\":"+strconv.FormatBool(masked))
 	}
 	payload := "{" + strings.Join(kvm, ",") + "}"
 
@@ -42,6 +45,23 @@ func Create(proxyName string, name string, encrypt bool) (respBody []byte, err e
 	}
 
 	respBody, err = apiclient.HttpClient(u.String(), payload)
+	return respBody, err
+}
+
+// Update
+func Update(proxyName string, name string, masked bool) (respBody []byte, err error) {
+	u, _ := url.Parse(apiclient.GetApigeeBaseURL())
+	payload := "{\"masked\":" + strconv.FormatBool(masked) + "}"
+
+	if apiclient.GetApigeeEnv() != "" {
+		u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "environments", apiclient.GetApigeeEnv(), "keyvaluemaps", name)
+	} else if proxyName != "" {
+		u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "apis", proxyName, "keyvaluemaps", name)
+	} else {
+		u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "keyvaluemaps", name)
+	}
+
+	respBody, err = apiclient.HttpClient(u.String(), payload, "PATCH")
 	return respBody, err
 }
 

--- a/internal/client/kvm/kvm_test.go
+++ b/internal/client/kvm/kvm_test.go
@@ -40,7 +40,7 @@ func TestCreate(t *testing.T) {
 	apiclient.SetApigeeEnv("")
 
 	// test org KVM
-	if _, err := Create("", kvmName, true); err != nil {
+	if _, err := Create("", kvmName, true, false); err != nil {
 		t.Fatalf("%v", err)
 	}
 
@@ -48,13 +48,13 @@ func TestCreate(t *testing.T) {
 	if _, err := apis.CreateProxy(proxyName, path.Join(cliPath, testFolder, "test_proxy.zip")); err != nil {
 		t.Fatalf("%v", err)
 	}
-	if _, err := Create(proxyName, kvmName, true); err != nil {
+	if _, err := Create(proxyName, kvmName, true, false); err != nil {
 		t.Fatalf("%v", err)
 	}
 
 	// test env KVM
 	apiclient.SetApigeeEnv(env)
-	if _, err := Create("", kvmName, true); err != nil {
+	if _, err := Create("", kvmName, true, false); err != nil {
 		t.Fatalf("%v", err)
 	}
 }

--- a/internal/cmd/kvm/impkvms.go
+++ b/internal/cmd/kvm/impkvms.go
@@ -50,7 +50,7 @@ var ImpCmd = &cobra.Command{
 				kvmFile := filepath.Base(orgKVMFile)
 				kvmMetadata := strings.Split(kvmFile, utils.DefaultFileSplitter)
 				clilog.Info.Printf("\tCreating KVM %s\n", orgKVMFile)
-				if _, err = kvm.Create("", kvmMetadata[1], true); proceedOnError(err) != nil {
+				if _, err = kvm.Create("", kvmMetadata[1], true, false); proceedOnError(err) != nil {
 					return err
 				}
 				clilog.Info.Printf("\tImporting entries for %s\n", orgKVMFile)
@@ -66,7 +66,7 @@ var ImpCmd = &cobra.Command{
 				kvmFile := filepath.Base(proxyKVMFile)
 				kvmMetadata := strings.Split(kvmFile, utils.DefaultFileSplitter)
 				clilog.Info.Printf("\tCreating KVM %s\n", proxyKVMFile)
-				if _, err = kvm.Create(kvmMetadata[1], kvmMetadata[2], true); proceedOnError(err) != nil {
+				if _, err = kvm.Create(kvmMetadata[1], kvmMetadata[2], true, false); proceedOnError(err) != nil {
 					return err
 				}
 				clilog.Info.Printf("\tImporting entries for %s\n", proxyKVMFile)
@@ -83,7 +83,7 @@ var ImpCmd = &cobra.Command{
 				kvmMetadata := strings.Split(kvmFile, utils.DefaultFileSplitter)
 				apiclient.SetApigeeEnv(kvmMetadata[1])
 				clilog.Info.Printf("\tCreating KVM %s\n", envKVMFile)
-				if _, err = kvm.Create("", kvmMetadata[2], true); proceedOnError(err) != nil {
+				if _, err = kvm.Create("", kvmMetadata[2], true, false); proceedOnError(err) != nil {
 					return err
 				}
 				clilog.Info.Printf("\tImporting entries for %s\n", envKVMFile)

--- a/internal/cmd/kvm/kvm.go
+++ b/internal/cmd/kvm/kvm.go
@@ -38,6 +38,7 @@ func init() {
 	Cmd.AddCommand(ListCmd)
 	Cmd.AddCommand(DelCmd)
 	Cmd.AddCommand(CreateCmd)
+	Cmd.AddCommand(UpdateCmd)
 	Cmd.AddCommand(ExpCmd)
 	Cmd.AddCommand(EntryCmd)
 	Cmd.AddCommand(ImpCmd)

--- a/internal/cmd/kvm/updkvm.go
+++ b/internal/cmd/kvm/updkvm.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,11 +22,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CreateCmd to create kvms
-var CreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create a KV Map",
-	Long:  "Create a KV Map",
+// UpdateCmd to update a kvm
+var UpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a KV Map",
+	Long:  "Update a KV Map",
 	Args: func(cmd *cobra.Command, args []string) (err error) {
 		if env != "" {
 			apiclient.SetApigeeEnv(env)
@@ -40,22 +40,20 @@ var CreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		cmd.SilenceUsage = true
 
-		_, err = kvm.Create(proxyName, name, true, masked)
+		_, err = kvm.Update(proxyName, name, masked)
 		return
 	},
 }
 
-var masked bool
-
 func init() {
-	CreateCmd.Flags().StringVarP(&env, "env", "e",
+	UpdateCmd.Flags().StringVarP(&env, "env", "e",
 		"", "Environment name")
-	CreateCmd.Flags().StringVarP(&proxyName, "proxy", "p",
+	UpdateCmd.Flags().StringVarP(&proxyName, "proxy", "p",
 		"", "API Proxy name")
-	CreateCmd.Flags().StringVarP(&name, "name", "n",
+	UpdateCmd.Flags().StringVarP(&name, "name", "n",
 		"", "KVM Map name")
-	CreateCmd.Flags().BoolVarP(&masked, "masked", "m",
+	UpdateCmd.Flags().BoolVarP(&masked, "masked", "m",
 		false, "Mask the KVM values in the debug session")
 
-	_ = CreateCmd.MarkFlagRequired("name")
+	_ = UpdateCmd.MarkFlagRequired("name")
 }

--- a/internal/cmd/org/import.go
+++ b/internal/cmd/org/import.go
@@ -81,7 +81,7 @@ var ImportCmd = &cobra.Command{
 			}
 			for _, kvmName := range kvmList {
 				// create only encrypted KVMs
-				if _, err = kvm.Create("", kvmName, true); err != nil {
+				if _, err = kvm.Create("", kvmName, true, false); err != nil {
 					return err
 				}
 				if orgKVMFileList[kvmName] != "" {
@@ -185,7 +185,7 @@ var ImportCmd = &cobra.Command{
 				}
 				for _, kvmName := range kvmList {
 					// create only encrypted KVMs
-					if _, err = kvm.Create("", kvmName, true); err != nil {
+					if _, err = kvm.Create("", kvmName, true, false); err != nil {
 						return err
 					}
 					if envKVMFileList[kvmName] != "" {


### PR DESCRIPTION
## Summary

- Adds `masked` parameter to `kvm.Create` so the Apigee `masked` field is set when requested
- Adds new `kvm.Update` function (PATCH) to update the masked setting on an existing KVM
- Adds `--masked`/`-m` flag to `apigeecli kvms create`
- Adds new `apigeecli kvms update` subcommand with the same flag
- Updates all existing `kvm.Create` call sites to pass `false` (no behaviour change)

## Test plan

- [ ] `apigeecli kvms create -n my-kvm --masked` creates a KVM with `"masked":true` in the payload
- [ ] `apigeecli kvms update -n my-kvm --masked=false` PATCHes the KVM with `"masked":false`
- [ ] Existing `kvms import` and `org import` flows continue to work unchanged

Closes #715

🤖 Generated with [Claude Code](https://claude.ai/claude-code)