### PR TITLE
feat: log revision number after proxy/sharedflow bundle import (#641)

### DIFF
--- a/internal/client/apis/apis.go
+++ b/internal/client/apis/apis.go
@@ -655,6 +655,13 @@ func importAPIProxies(wg *sync.WaitGroup, jobs <-chan string, space string, errs
 			continue
 		}
 
+		var importResp struct {
+			Revision string `json:"revision"`
+		}
+		if err = json.Unmarshal(b, &importResp); err == nil && importResp.Revision != "" {
+			clilog.Info.Printf("Imported proxy %s revision %s\n", n, importResp.Revision)
+		}
+
 		if len(b) > 0 && apiclient.GetPrintOutput() {
 			out := bytes.NewBuffer([]byte{})
 			if err = json.Indent(out, bytes.TrimSpace(b), "", "  "); err != nil {

--- a/internal/client/sharedflows/sharedflows.go
+++ b/internal/client/sharedflows/sharedflows.go
@@ -522,6 +522,13 @@ func importSharedFlows(wg *sync.WaitGroup, jobs <-chan string, space string, err
 			continue
 		}
 
+		var importResp struct {
+			Revision string `json:"revision"`
+		}
+		if err = json.Unmarshal(b, &importResp); err == nil && importResp.Revision != "" {
+			clilog.Info.Printf("Imported shared flow %s revision %s\n", n, importResp.Revision)
+		}
+
 		if len(b) > 0 && apiclient.GetPrintOutput() {
 			out := bytes.NewBuffer([]byte{})
 			if err = json.Indent(out, bytes.TrimSpace(b), "", "  "); err != nil {


### PR DESCRIPTION
## Summary

- After a successful `apis import` or `sharedflows import`, the Apigee API returns the new revision number in the response body
- This change logs that revision at INFO level for each bundle: `Imported proxy <name> revision <N>`
- Operators can now confirm which revision was created without having to query the API separately

## Test plan

- [ ] Run `apigeecli apis import -f <folder>` and verify `Imported proxy X revision N` lines appear in stdout
- [ ] Run `apigeecli sharedflows import -f <folder>` and verify similar lines for shared flows
- [ ] Verify behaviour is unchanged when the response body lacks a `revision` field

Closes #641

🤖 Generated with [Claude Code](https://claude.ai/claude-code)