### PR TITLE
fix: preserve API product approval status when importing apps (#661)

### DIFF
--- a/internal/client/apps/apps.go
+++ b/internal/client/apps/apps.go
@@ -60,7 +60,8 @@ type credential struct {
 }
 
 type apiProduct struct {
-	Name string `json:"apiproduct,omitempty"`
+	Name   string `json:"apiproduct,omitempty"`
+	Status string `json:"status,omitempty"`
 }
 
 type importCredential struct {
@@ -539,6 +540,18 @@ func createAsyncApp(app application, developerEntities developers.Appdevelopers,
 			_, err = apiclient.HttpClient(updateDeveloperAppUrl.String(), string(updateCredJSON))
 			if err != nil {
 				return
+			}
+
+			// set the API product status on the credential if it was approved
+			for _, apiProd := range credential.APIProducts {
+				if apiProd.Status == "approved" {
+					apiclient.ClientPrintHttpResponse.Set(false)
+					_, err = ManageKey(url.QueryEscape(developerEmail), app.Name, credential.ConsumerKey, "approve", apiProd.Name)
+					apiclient.ClientPrintHttpResponse.Set(apiclient.GetCmdPrintHttpResponseSetting())
+					if err != nil {
+						clilog.Warning.Printf("failed to approve API product %s on key %s: %v\n", apiProd.Name, credential.ConsumerKey, err)
+					}
+				}
 			}
 		} else {
 			clilog.Warning.Println("NOTE: apiProducts are not associated with the app")

--- a/internal/client/apps/keys_test.go
+++ b/internal/client/apps/keys_test.go
@@ -52,7 +52,7 @@ func TestManageKey(t *testing.T) {
 		clienttest.SITEID_NOT_REQD, clienttest.CLIPATH_NOT_REQD); err != nil {
 		t.Fatalf("%v", err)
 	}
-	if _, err := ManageKey(name, appID, "key1", "approve"); err != nil {
+	if _, err := ManageKey(name, appID, "key1", "approve", ""); err != nil {
 		t.Fatalf("%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- When exporting apps, each credential's `apiProducts` list includes a `status` field (`approved`/`revoked`)
- During import the code only associated products with the key but never called the approve action, leaving all products in the default revoked state
- Adds `Status` to the `apiProduct` struct so it is deserialised from the export file
- After updating credentials, calls `ManageKey(..., "approve", product)` for every product that had `"status": "approved"` in the export
- Also fixes a pre-existing vet error in `keys_test.go` where `ManageKey` was called with 4 arguments instead of the required 5

## Test plan

- [ ] Export an app that has an approved API product association
- [ ] Import it into a target org with `apigeecli apps import`
- [ ] Verify the key's product association shows `approved` status after import

Closes #661

🤖 Generated with [Claude Code](https://claude.ai/claude-code)