### PR TITLE
feat: add --skip-ssl-verify and --override-base-url global flags (#675)

### DIFF
--- a/internal/apiclient/httpclient.go
+++ b/internal/apiclient/httpclient.go
@@ -17,6 +17,7 @@ package apiclient
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -394,12 +395,15 @@ func GetHttpClient() (err error) {
 		apiRateLimit = noAPIRateLimit
 	}
 
+	tlsCfg := &tls.Config{InsecureSkipVerify: GetSkipSSLVerify()} //nolint:gosec
+
 	if GetProxyURL() != "" {
 		if proxyUrl, err := url.Parse(GetProxyURL()); err == nil {
 			ApigeeAPIClient = &RateLimitedHTTPClient{
 				client: &http.Client{
 					Transport: &http.Transport{
-						Proxy: http.ProxyURL(proxyUrl),
+						Proxy:           http.ProxyURL(proxyUrl),
+						TLSClientConfig: tlsCfg,
 					},
 				},
 				Ratelimiter: apiRateLimit,
@@ -409,7 +413,11 @@ func GetHttpClient() (err error) {
 		}
 	} else {
 		ApigeeAPIClient = &RateLimitedHTTPClient{
-			client:      http.DefaultClient,
+			client: &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: tlsCfg,
+				},
+			},
 			Ratelimiter: apiRateLimit,
 		}
 	}

--- a/internal/apiclient/options.go
+++ b/internal/apiclient/options.go
@@ -51,10 +51,12 @@ type ApigeeClientOptions struct {
 	PrintOutput    bool   // prints output from http calls
 	NoOutput       bool   // Disable all statements to stdout
 	NoWarnings     bool   // Disable printing warnings to stderr
-	ProxyUrl       string // use a proxy url
-	MetadataToken  bool   // use metadata outh2 token
-	APIRate        Rate   // throttle api calls to Apigee
-	Region         string // control plane region
+	ProxyUrl        string // use a proxy url
+	MetadataToken   bool   // use metadata outh2 token
+	APIRate         Rate   // throttle api calls to Apigee
+	Region          string // control plane region
+	SkipSSLVerify   bool   // skip TLS certificate verification
+	OverrideBaseURL string // override the Apigee base URL
 	// Space          string // Apigee space
 }
 
@@ -125,6 +127,8 @@ func NewApigeeClient(o ApigeeClientOptions) {
 	options.PrintOutput = o.PrintOutput
 	options.NoOutput = o.NoOutput
 	options.NoWarnings = o.NoWarnings
+	options.SkipSSLVerify = o.SkipSSLVerify
+	options.OverrideBaseURL = o.OverrideBaseURL
 
 	// initialize logs
 	clilog.Init(options.DebugLog, options.PrintOutput, options.NoOutput, options.NoWarnings)
@@ -348,8 +352,31 @@ func GetAPIObserveURL() (apiObserveURL string) {
 	return fmt.Sprintf(apiObserveBaseURL, options.ProjectID, options.Region)
 }
 
+// SetSkipSSLVerify
+func SetSkipSSLVerify(skip bool) {
+	options.SkipSSLVerify = skip
+}
+
+// GetSkipSSLVerify
+func GetSkipSSLVerify() bool {
+	return options.SkipSSLVerify
+}
+
+// SetOverrideBaseURL
+func SetOverrideBaseURL(u string) {
+	options.OverrideBaseURL = u
+}
+
+// GetOverrideBaseURL
+func GetOverrideBaseURL() string {
+	return options.OverrideBaseURL
+}
+
 // GetApigeeBaseURL
 func GetApigeeBaseURL() string {
+	if options.OverrideBaseURL != "" {
+		return options.OverrideBaseURL
+	}
 	if options.Region != "" {
 		return fmt.Sprintf(baseDRZURL, options.Region)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -130,8 +130,9 @@ func Execute() {
 }
 
 var (
-	accessToken, serviceAccount                                                  string
+	accessToken, serviceAccount, overrideBaseURL                                 string
 	disableCheck, printOutput, noOutput, metadataToken, defaultToken, noWarnings bool
+	skipSSLVerify                                                                bool
 	api                                                                          apiclient.API
 )
 
@@ -166,6 +167,12 @@ func init() {
 
 	RootCmd.PersistentFlags().Var(&api, "api", "Sets the control plane API. Must be one of prod, autopush "+
 		"or staging; default is prod")
+
+	RootCmd.PersistentFlags().BoolVarP(&skipSSLVerify, "skip-ssl-verify", "",
+		false, "Skip TLS certificate verification (not recommended for production)")
+
+	RootCmd.PersistentFlags().StringVarP(&overrideBaseURL, "override-base-url", "",
+		"", "Override the Apigee base URL (e.g. for local proxies or testing)")
 
 	RootCmd.AddCommand(apis.Cmd)
 	RootCmd.AddCommand(org.Cmd)
@@ -215,17 +222,26 @@ func initConfig() {
 
 	skipCache, _ = strconv.ParseBool(os.Getenv("APIGEECLI_SKIPCACHE"))
 
+	if os.Getenv("APIGEECLI_SKIP_SSL_VERIFY") == ENABLED {
+		skipSSLVerify = true
+	}
+	if envOverride := os.Getenv("APIGEECLI_OVERRIDE_BASE_URL"); envOverride != "" {
+		overrideBaseURL = envOverride
+	}
+
 	if noOutput {
 		printOutput = noOutput
 	}
 
 	apiclient.NewApigeeClient(apiclient.ApigeeClientOptions{
-		TokenCheck:  true,
-		PrintOutput: printOutput,
-		NoOutput:    noOutput,
-		DebugLog:    debug,
-		SkipCache:   skipCache,
-		NoWarnings:  noWarnings,
+		TokenCheck:      true,
+		PrintOutput:     printOutput,
+		NoOutput:        noOutput,
+		DebugLog:        debug,
+		SkipCache:       skipCache,
+		NoWarnings:      noWarnings,
+		SkipSSLVerify:   skipSSLVerify,
+		OverrideBaseURL: overrideBaseURL,
 	})
 
 	if os.Getenv("APIGEECLI_ENABLE_RATELIMIT") == ENABLED {


### PR DESCRIPTION
## Summary

- Adds two new persistent (global) flags and matching environment variables:
  - `--skip-ssl-verify` / `APIGEECLI_SKIP_SSL_VERIFY=true` — disables TLS certificate verification (useful behind a corporate MITM proxy; not recommended for production)
  - `--override-base-url <url>` / `APIGEECLI_OVERRIDE_BASE_URL=<url>` — replaces the computed Apigee control-plane base URL entirely (useful for local emulators or testing)
- Adds `SkipSSLVerify` and `OverrideBaseURL` fields to `ApigeeClientOptions`
- `GetApigeeBaseURL()` checks the override before computing the region/API-specific URL
- `GetHttpClient()` creates an `http.Transport` with `tls.Config.InsecureSkipVerify` so both proxy and non-proxy paths respect the flag

## Test plan

- [ ] `apigeecli --skip-ssl-verify orgs get -o <org>` connects without verifying the server cert
- [ ] `APIGEECLI_OVERRIDE_BASE_URL=http://localhost:8080/v1/organizations/ apigeecli orgs get -o test` hits the local server
- [ ] Normal (no flags) operation is unchanged — TLS verification is on by default

Closes #675

🤖 Generated with [Claude Code](https://claude.ai/claude-code)