### PR TITLE
fix: include (not set) proxy type calls in standard and total counts (#714)

### DIFF
--- a/internal/client/env/reports.go
+++ b/internal/client/env/reports.go
@@ -120,16 +120,19 @@ func totalAPICallsInMonth(dimension bool, environment string, month int, year in
 					for _, m := range d.Metrics {
 						calls, _ := strconv.Atoi(m.Values[0])
 						totalExtensible = totalExtensible + calls
+						totalApiCalls = totalApiCalls + calls
 					}
 				} else if d.Name == "STANDARD" {
 					for _, m := range d.Metrics {
 						calls, _ := strconv.Atoi(m.Values[0])
 						totalStandard = totalStandard + calls
+						totalApiCalls = totalApiCalls + calls
 					}
 				} else if d.Name == "(not set)" {
 					for _, m := range d.Metrics {
 						calls, _ := strconv.Atoi(m.Values[0])
 						totalApiCalls = totalApiCalls + calls
+						totalStandard = totalStandard + calls
 					}
 				}
 			} else {


### PR DESCRIPTION
## Summary

- When `proxy_deployment_type` dimension returns `(not set)` values, those API calls were added to `totalApiCalls` but silently dropped from `totalStandard`, making them invisible in the `--proxy-type` billing report output
- `EXTENSIBLE` and `STANDARD` dimension calls also did not contribute to `totalApiCalls`, so the total count only reflected unclassified proxies when dimension mode was active
- Fixed by accumulating all dimension values (`EXTENSIBLE`, `STANDARD`, `(not set)`) into `totalApiCalls`, and also crediting `(not set)` calls to `totalStandard` (unclassified proxies are not extensible and should count as standard)

Fixes #714

## Test plan

- [ ] Run `apigeecli reports total-api-calls --proxy-type` against an environment that has proxies with mixed or missing deployment types
- [ ] Verify the standard count now includes calls from proxies with `(not set)` deployment type
- [ ] Verify the total count matches extensible + standard

🤖 Generated with [Claude Code](https://claude.com/claude-code)