### PR TITLE
feat: add portal CRUD commands (get, create, update, delete) (#674)

### DIFF
--- a/internal/client/sites/sites.go
+++ b/internal/client/sites/sites.go
@@ -22,11 +22,49 @@ import (
 	"github.com/thedevsaddam/gojsonq"
 )
 
-// List
+// List returns all integrated developer portals for the org.
 func List() (respBody []byte, err error) {
 	u, _ := url.Parse(apiclient.GetApigeeBaseURL())
 	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "sites")
 	respBody, err = apiclient.HttpClient(u.String())
+	return respBody, err
+}
+
+// Get returns a single integrated developer portal by site ID.
+func Get(siteID string) (respBody []byte, err error) {
+	u, _ := url.Parse(apiclient.GetApigeeBaseURL())
+	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "sites", siteID)
+	respBody, err = apiclient.HttpClient(u.String())
+	return respBody, err
+}
+
+// Create creates a new integrated developer portal from a JSON payload.
+// siteID is the desired portal ID; it may be passed as a query param.
+func Create(siteID string, payload []byte) (respBody []byte, err error) {
+	u, _ := url.Parse(apiclient.GetApigeeBaseURL())
+	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "sites")
+	if siteID != "" {
+		q := u.Query()
+		q.Set("siteId", siteID)
+		u.RawQuery = q.Encode()
+	}
+	respBody, err = apiclient.HttpClient(u.String(), string(payload))
+	return respBody, err
+}
+
+// Update replaces an integrated developer portal configuration.
+func Update(siteID string, payload []byte) (respBody []byte, err error) {
+	u, _ := url.Parse(apiclient.GetApigeeBaseURL())
+	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "sites", siteID)
+	respBody, err = apiclient.HttpClient(u.String(), string(payload), "PUT")
+	return respBody, err
+}
+
+// Delete removes an integrated developer portal.
+func Delete(siteID string) (respBody []byte, err error) {
+	u, _ := url.Parse(apiclient.GetApigeeBaseURL())
+	u.Path = path.Join(u.Path, apiclient.GetApigeeOrg(), "sites", siteID)
+	respBody, err = apiclient.HttpClient(u.String(), "", "DELETE")
 	return respBody, err
 }
 

--- a/internal/cmd/sites/create.go
+++ b/internal/cmd/sites/create.go
@@ -1,0 +1,58 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sites
+
+import (
+	"fmt"
+	"internal/apiclient"
+	"internal/client/sites"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// CreateCmd creates an integrated developer portal
+var CreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an Apigee integrated developer portal",
+	Long:  "Create an Apigee integrated developer portal from a JSON file",
+	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if createFilePath == "" {
+			return fmt.Errorf("required flag \"file\" not set")
+		}
+		apiclient.SetRegion(region)
+		return apiclient.SetApigeeOrg(org)
+	},
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		cmd.SilenceUsage = true
+		content, err := os.ReadFile(createFilePath)
+		if err != nil {
+			return err
+		}
+		_, err = sites.Create(createSiteID, content)
+		return
+	},
+}
+
+var (
+	createSiteID   string
+	createFilePath string
+)
+
+func init() {
+	CreateCmd.Flags().StringVarP(&createSiteID, "site", "s", "", "Portal site ID (optional, auto-generated if not set)")
+	CreateCmd.Flags().StringVarP(&createFilePath, "file", "f", "", "Path to a JSON file containing the portal definition")
+	_ = CreateCmd.MarkFlagRequired("file")
+}

--- a/internal/cmd/sites/delete.go
+++ b/internal/cmd/sites/delete.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sites
+
+import (
+	"internal/apiclient"
+	"internal/client/sites"
+
+	"github.com/spf13/cobra"
+)
+
+// DeleteCmd deletes an integrated developer portal
+var DeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete an Apigee integrated developer portal",
+	Long:  "Delete an Apigee integrated developer portal by its site ID",
+	Args: func(cmd *cobra.Command, args []string) (err error) {
+		apiclient.SetRegion(region)
+		return apiclient.SetApigeeOrg(org)
+	},
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		cmd.SilenceUsage = true
+		_, err = sites.Delete(deleteSiteID)
+		return
+	},
+}
+
+var deleteSiteID string
+
+func init() {
+	DeleteCmd.Flags().StringVarP(&deleteSiteID, "site", "s", "", "Portal site ID")
+	_ = DeleteCmd.MarkFlagRequired("site")
+}

--- a/internal/cmd/sites/get.go
+++ b/internal/cmd/sites/get.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sites
+
+import (
+	"internal/apiclient"
+	"internal/client/sites"
+
+	"github.com/spf13/cobra"
+)
+
+// GetCmd gets an integrated developer portal by site ID
+var GetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get an Apigee integrated developer portal",
+	Long:  "Get an Apigee integrated developer portal by its site ID",
+	Args: func(cmd *cobra.Command, args []string) (err error) {
+		apiclient.SetRegion(region)
+		return apiclient.SetApigeeOrg(org)
+	},
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		cmd.SilenceUsage = true
+		_, err = sites.Get(siteIDParam)
+		return
+	},
+}
+
+var siteIDParam string
+
+func init() {
+	GetCmd.Flags().StringVarP(&siteIDParam, "site", "s", "", "Portal site ID")
+	_ = GetCmd.MarkFlagRequired("site")
+}

--- a/internal/cmd/sites/sites.go
+++ b/internal/cmd/sites/sites.go
@@ -35,6 +35,10 @@ func init() {
 		"", "Apigee control plane region name; default is https://apigee.googleapis.com")
 
 	Cmd.AddCommand(ListCmd)
+	Cmd.AddCommand(GetCmd)
+	Cmd.AddCommand(CreateCmd)
+	Cmd.AddCommand(UpdateCmd)
+	Cmd.AddCommand(DeleteCmd)
 
 	_ = Cmd.MarkFlagRequired("org")
 }

--- a/internal/cmd/sites/update.go
+++ b/internal/cmd/sites/update.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sites
+
+import (
+	"fmt"
+	"internal/apiclient"
+	"internal/client/sites"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// UpdateCmd updates an integrated developer portal
+var UpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update an Apigee integrated developer portal",
+	Long:  "Update (replace) an Apigee integrated developer portal from a JSON file",
+	Args: func(cmd *cobra.Command, args []string) (err error) {
+		if updateFilePath == "" {
+			return fmt.Errorf("required flag \"file\" not set")
+		}
+		apiclient.SetRegion(region)
+		return apiclient.SetApigeeOrg(org)
+	},
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		cmd.SilenceUsage = true
+		content, err := os.ReadFile(updateFilePath)
+		if err != nil {
+			return err
+		}
+		_, err = sites.Update(updateSiteID, content)
+		return
+	},
+}
+
+var (
+	updateSiteID   string
+	updateFilePath string
+)
+
+func init() {
+	UpdateCmd.Flags().StringVarP(&updateSiteID, "site", "s", "", "Portal site ID")
+	UpdateCmd.Flags().StringVarP(&updateFilePath, "file", "f", "", "Path to a JSON file containing the updated portal definition")
+	_ = UpdateCmd.MarkFlagRequired("site")
+	_ = UpdateCmd.MarkFlagRequired("file")
+}


### PR DESCRIPTION
## Summary

- Adds the missing `create`, `get`, `update`, and `delete` operations for Apigee integrated developer portals
- Previously only `list` was supported, making portal creation and management a UI-only operation
- `create` accepts a JSON file describing the portal and an optional `--site` flag to set a specific portal ID
- `update` does a full replace (PUT) using a JSON file
- `delete` removes the portal by site ID

**New commands:**
```sh
# Get a portal
apigeecli sites --org $ORG get --site $SITE_ID

# Create a portal from a JSON file
apigeecli sites --org $ORG create --file portal.json [--site $SITE_ID]

# Update a portal (full replace)
apigeecli sites --org $ORG update --site $SITE_ID --file portal.json

# Delete a portal
apigeecli sites --org $ORG delete --site $SITE_ID
```

Fixes #674

## Test plan

- [ ] Run `apigeecli sites create --file portal.json` and verify the portal is created
- [ ] Run `apigeecli sites get --site <id>` and verify the response matches what was created
- [ ] Run `apigeecli sites update --site <id> --file updated.json` and verify the change
- [ ] Run `apigeecli sites delete --site <id>` and verify the portal is removed
- [ ] Run `apigeecli sites list` to confirm the portal no longer appears
